### PR TITLE
[feature] Add 'ignorePermissionErrors' option. (Closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ watcher.close();
     `chokidar.watch('file', {ignored: /^\./})`.
     * `options.persistent` (default: `false`). indicates whether the process
     should continue to run as long as files are being watched.
-
+    * `options.ignorePermissionErrors` (default: `false`). indicates
+      wether to watch files that don't have read permissions or not.
+    
 `chokidar.watch()` produces an instance of `FSWatcher`. Methods of `FSWatcher`:
 
 * `.add(file / files)`: add directories / files for tracking.


### PR DESCRIPTION
As discussed in #20 this adds the option `ignorePermissionErrors` to ignore files for that are not readable.

I've tested it on OS X 10.7, so it should be fine for unix systems. From what I've found this should also work on windows but I have no machine to test it on right now.
