### PR TITLE
Fixing small bug in FSWatcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chokidar",
   "description": "A neat wrapper around node.js fs.watch / fs.watchFile.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "keywords": ["fs", "watch", "watchFile", "watcher", "file"],
   "homepage": "https://github.com/paulmillr/chokidar",
   "author": "Paul Miller (http://paulmillr.com)",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -178,7 +178,7 @@ exports.FSWatcher = class FSWatcher extends EventEmitter
     fs.realpath item, (error, path) =>
       return @emit 'error', error if error?
       # Get file info, check is it file, directory or something else.
-      fs.stat item, (error, stats) =>
+      fs.stat path, (error, stats) =>
         return @emit 'error', error if error?
         if @options.ignorePermissionErrors and (not @_hasReadPermissions stats)
           return


### PR DESCRIPTION
Fixes a small typo where a relative path is converted to absolute. Then the relative path is used (not the new one that is left unused).

Thanks in advance,
