### PR TITLE
Use fs.watch on unix-like platforms

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -107,7 +107,9 @@ exports.FSWatcher = class FSWatcher extends EventEmitter
     return if parent.indexOf(basename) >= 0
 
     @_addToWatchedDir directory, basename
-    if process.platform is 'win32' and nodeVersion is '0.6'
+
+    unixlike = process.platform in ['darwin', 'freebsd', 'linux', 'sunos']
+    if (unixlike or process.platform is 'win32' and nodeVersion is '0.6')
       watcher = fs.watch item, options, (event, path) =>
         callback item
       @watchers.push watcher


### PR DESCRIPTION
Chokidar uses polling for watching on everything that is not node v0.6 and win32. It may cause up to 50% of process time of one core when watching big file trees.

And not sure if we still need that check for win32 and v0.6
