### PR TITLE
Delay file removal to fix vim backupcopy issue

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -157,7 +157,14 @@ exports.FSWatcher = class FSWatcher extends EventEmitter
           .filter (file) =>
             current.indexOf(file) is -1
           .forEach (file) =>
-            @_remove directory, file
+            fullPath = sysPath.join directory, file
+            setTimeout =>
+              fs.exists fullPath, (exists) =>
+                if exists
+                  @_handle fullPath, false
+                else
+                  @_remove directory, file
+            , 50
 
         # Files that present in current directory snapshot
         # but absent in previous are added to watch list and


### PR DESCRIPTION
I wasn't able to reproduce the issue actually using vim, but I was able to do so using the `mv file.js file.js.swp && sleep .1 && mv file.js.swp file.js` emulation method. This patch does appear to cause the desired behavior of handling the event as a change instead of an unlink with no subsequent add.

Aside from a very slight delay in unlink events, I am not sure whether this will lead to unwanted side-effects. It would be great if people could try it out with various use-cases to see how it goes - particularly those who can consistently make it happen with vim.
