### PR TITLE
Fix for unlink events on empty directories

### DIFF
--- a/test/chokidar-test.coffee
+++ b/test/chokidar-test.coffee
@@ -92,6 +92,19 @@ describe 'chokidar', ->
           spy.should.have.been.calledWith testPath
           done()
 
+    it 'should not emit `unlink` event when a empty directory was removed', (done) ->
+      spy = sinon.spy()
+      testDir = getFixturePath 'subdir'
+
+      @watcher.on 'unlink', spy
+
+      delay =>
+        fs.mkdirSync testDir, 0o755
+        fs.rmdirSync testDir
+        delay =>
+          spy.should.not.have.been.called
+          done()
+
     it 'should survive ENOENT for missing subdirectories', ->
       testDir = getFixturePath 'subdir'
 


### PR DESCRIPTION
Chokidar was emitting unlink events for empty directories, but it never emitted any other events for these, so they had the potential to confuse applications.

This also contains a fix where the `watched` object got cluttered with file paths in the `_remove` function, turns out that it always created a directory entry even if the path was a file, I made it so that in both cases the directory entry gets destroyed if it exists. This takes care of both cases (a file cluttering the object, and a directory being fully removed).

I also added a corresponding test case, please not that there's still one test failing, but that also happens on a fresh checkout from master.
