### PR TITLE
Add second check for ignored items (after stating the fs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ watcher.close();
 * `chokidar.watch(paths, options)`: takes paths to be watched and options:
     * `options.ignored` (regexp or function) files to be ignored.
       This function or regexp is tested against the **whole path**,
-      not just filename. Example:
-    `chokidar.watch('file', {ignored: /^\./})`.
+      not just filename. If it is a function with two arguments, it gets called
+      twice per path - once with a single argument (the path), second time with
+      two arguments (the path and the [`fs.Stats`](http://nodejs.org/api/fs.html#fs_class_fs_stats)
+      object of that path).
     * `options.persistent` (default: `false`). Indicates whether the process
     should continue to run as long as files are being watched.
     * `options.ignorePermissionErrors` (default: `false`). Indicates

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -191,6 +191,8 @@ exports.FSWatcher = class FSWatcher extends EventEmitter
         if @options.ignorePermissionErrors and (not @_hasReadPermissions stats)
           return
 
+        return if @_ignored.length is 2 and @_ignored item, stats
+
         @_handleFile item, stats, initialAdd if stats.isFile()
         @_handleDir item, initialAdd if stats.isDirectory()
 

--- a/test/chokidar-test.coffee
+++ b/test/chokidar-test.coffee
@@ -121,11 +121,15 @@ describe 'chokidar', ->
 
       before (done) ->
         try fs.unlinkSync getFixturePath('subdir/add.txt')
+        try fs.unlinkSync getFixturePath('subdir/dir/ignored.txt')
+        try fs.rmdirSync getFixturePath('subdir/dir')
         try fs.rmdirSync getFixturePath('subdir')
         done()
 
       after (done) ->
         try fs.unlinkSync getFixturePath('subdir/add.txt')
+        try fs.unlinkSync getFixturePath('subdir/dir/ignored.txt')
+        try fs.rmdirSync getFixturePath('subdir/dir')
         try fs.rmdirSync getFixturePath('subdir')
         done()
 
@@ -156,6 +160,29 @@ describe 'chokidar', ->
             spy.should.have.been.calledOnce
             spy.should.have.been.calledWith testPath
             done()
+
+      it 'should check ignore after stating', (done) ->
+        testDir = getFixturePath 'subdir'
+        spy = sinon.spy()
+
+        ignoredFn = (path, stats) ->
+          return no if path is testDir or not stats
+          # ignore directories
+          return stats.isDirectory()
+
+        watcher = chokidar.watch testDir, {ignored: ignoredFn}
+        watcher.on 'add', spy
+
+        fs.mkdirSync testDir, 0o755
+        fs.writeFileSync testDir + '/add.txt', ''         # this file should be added
+        fs.mkdirSync testDir + '/dir', 0o755              # this dir will be ignored
+        fs.writeFileSync testDir + '/dir/ignored.txt', '' # so this file should be ignored
+
+        delay ->
+          spy.should.have.been.calledOnce
+          spy.should.have.been.calledWith testDir + '/add.txt'
+          done()
+
 
 describe 'is-binary', ->
   it 'should be a function', ->


### PR DESCRIPTION
When deciding if an item should be ignored, it is helpful to know whether it is a file or a directory. Delaying the check after we have the stats information would mean unnecessary stat calls for those items that can be ignored based on the path.

This is a breaking change:
The `ignored` function will be called twice for each new item - once without the stats object, then again once we have the stats information.

Closes #51
