### PR TITLE
Upgrade fsevents to 0.2.0

### DIFF
--- a/setup-deps.js
+++ b/setup-deps.js
@@ -11,5 +11,5 @@ var execute = function(path, params, callback) {
 };
 
 if (require('os').platform() === 'darwin') {
-  execute('npm', 'install fsevents@0.1.6 recursive-readdir@0.0.2');
+  execute('npm', 'install fsevents@0.2.0 recursive-readdir@0.0.2');
 }


### PR DESCRIPTION
I realize this may have wide-reaching implications, but there are some good bug fixes in fsevents 0.2.0.

Would it be possible to merge this in? I've had to fork chokidar and do some shrinkwrap juggling to get a build working on certain OSX versions.
