### PR TITLE
Implement ready event. Fixes #102

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ watcher
   .on('unlink', function(path) {console.log('File', path, 'has been removed');})
   .on('unlinkDir', function(path) {console.log('Directory', path, 'has been removed');})
   .on('error', function(error) {console.error('Error happened', error);})
+  .on('ready', function() {console.log('Files has been added and ready to detect changes')})
 
 // 'add', 'addDir' and 'change' events also receive stat() results as second argument.
 // http://nodejs.org/api/fs.html#fs_class_fs_stats


### PR DESCRIPTION
A ready event for every `.add` call seems appropriate to notify the user that we're ready to detect file changes.
