### PR TITLE
added a test for single add event for single file

### DIFF
--- a/test.js
+++ b/test.js
@@ -94,6 +94,43 @@ describe('chokidar', function() {
         });
       });
     });
+
+
+    it('should emit single `add` event for single file added', function(done) {
+	    var spy, spy2, testPath, testPath2,
+		_this = this;
+	    spy = sinon.spy();
+	    spy2 = sinon.spy();
+
+	    testPath = getFixturePath('add.txt');
+	    testPath2 = getFixturePath('add2.txt');
+
+	    this.watcher.on('add', spy);
+	    return delay(function() {
+		    spy.should.not.have.been.called;
+		    fs.writeFileSync(testPath, 'hello');
+
+		    return delay(function() {
+			    spy.should.have.been.calledOnce;
+			    spy.should.have.been.calledWith(testPath);
+
+			    this.watcher.on('add', spy2);
+			    return delay(function(){
+
+				    spy2.should.not.have.been.called;
+				    fs.writeFileSync(testPath2, 'hello');
+
+				    return delay(function(){
+					    spy2.should.have.been.calledOnce;
+					    spy2.should.have.been.calledWith(testPath2);
+					    return done();
+					});
+				});
+			});
+		});
+	});
+
+
     it('should emit `addDir` event when directory was added', function(done) {
       var spy, testDir,
         _this = this;


### PR DESCRIPTION
This test isn't failing as I expected it to but may help elucidate the problem of multiple 'add' events when a single file is added.
