### PR TITLE
Bugfix: check that the error is not a FileNotFound (ENOENT) error

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,6 +336,7 @@ FSWatcher.prototype._handle = function(item, initialAdd) {
     if (error && error.code === 'ENOENT') return;
     if (error != null) return _this._emitError(error);
     fs.stat(path, function(error, stats) {
+      if (error && error.code === 'ENOENT') return;
       if (error != null) return _this._emitError(error);
       if (_this.options.ignorePermissionErrors && (!_this._hasReadPermissions(stats))) {
         return;


### PR DESCRIPTION
Hello there,

we encounter a bug for some months now, in our tests. We tracked down the issue and found a bug in chokidar. To make a long story short, chokidar issues an _fs.realpath_, and ignore the result if there is a ENOENT error. Then it issues a _fs.stat_ call, but take for granted that the file hasn't been removed in the interval, which is obviously false under certain workloads.

Hope you'll like it.
