### PR TITLE
Update createFSEventsInstance to use fsevents start()

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,8 +174,9 @@ FSWatcher.prototype._remove = function(directory, item) {
 
 // FS Events helper.
 var createFSEventsInstance = function(path, callback) {
-  var watcher = new fsevents.FSEvents(path);
+  var watcher = new fsevents(path);
   watcher.on('fsevent', callback);
+  watcher.start()
   return watcher;
 };
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rimraf": "~2.2.2"
   },
   "optionalDependencies": {
-    "fsevents": "0.2.0",
+    "fsevents": "git+http://user@hostname/pipobscure/fsevents.git#7dcdf9fa3f8956610fd6f69f72c67bace2de7138",
     "recursive-readdir": "0.0.2"
   }
 }


### PR DESCRIPTION
The reasons for this change are better explained in #125. 

I'm not in love with the idea of referencing a specific sha, but since it's an optionalDependency and there is already a [check](https://github.com/paulmillr/chokidar/blob/master/index.js#L66) to ensure it was loaded and requireable before it can be used I don't see too much harm in it.  

Also, it can be switched to the v0.2.1 as soon as fsevents pushes its next release.

The test script included in the issue was satisfied by the changes in this PR.  However, it needs set the `persistent: true` in order to live monitor the events (this was likely a typo when I saved it to the gist).  

I've updated it [here](https://gist.github.com/rondale-sc/75f5bf2067ce0784df52).

:)
