### PR TITLE
Allow FS events if not on windows but polling not set to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function FSWatcher(_opts) {
   if (opts.ignoreInitial == null) opts.ignoreInitial = false;
   if (opts.interval == null) opts.interval = 100;
   if (opts.binaryInterval == null) opts.binaryInterval = 300;
-  if (opts.usePolling == null) opts.usePolling = !isWindows;
+  if (opts.usePolling == null) opts.usePolling = (!isWindows && !canUseFsEvents);
   if (opts.useFsEvents == null) {
     opts.useFsEvents = !opts.usePolling && canUseFsEvents;
   } else {


### PR DESCRIPTION
When `opts.usePolling` was null, but you were on a `canUseFsEvents` platform, `opts.usePolling` would get set to true, thereby negating `canUseFsEvents`. I feel this makes the defaults a bit more sane.
