### PR TITLE
src: add support for character devices

### DIFF
--- a/index.js
+++ b/index.js
@@ -353,7 +353,7 @@ FSWatcher.prototype._handle = function(item, initialAdd) {
       if (_this._isIgnored.length === 2 && _this._isIgnored(item, stats)) {
         return;
       }
-      if (stats.isFile()) _this._handleFile(item, stats, initialAdd);
+      if (stats.isFile() || stats.isCharacterDevice()) _this._handleFile(item, stats, initialAdd);
       if (stats.isDirectory()) _this._handleDir(item, stats, initialAdd);
     });
   });


### PR DESCRIPTION
It's working in my Linux machine. I don't know how it'll work for other OS

You can test this creating a character device just like this:

```
mknod  /tmp/my_device c 400 1
```

The problem is that you need to be root and I'm not sure if you want to run something like `sudo mknod ...` in the tests. In case you are ok I can add a couple of tests checking device creation / deletion
