### PR TITLE
fix: Closing a chokidar instance prevent other instances to watch a file

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function FSWatcher(_opts) {
   this.watched = Object.create(null);
   this.watchers = [];
   this.closed = false;
-  this.callbacks = Object.create(null);
+  this.listeners = Object.create(null);
 
   // Set up default options.
   if (opts.persistent == null) opts.persistent = false;
@@ -168,8 +168,8 @@ FSWatcher.prototype._remove = function(directory, item) {
   }, this);
 
   if (this.options.usePolling) {
-    fs.unwatchFile(absolutePath, this.callbacks[absolutePath]);
-    delete this.callbacks[absolutePath];
+    fs.unwatchFile(absolutePath, this.listeners[absolutePath]);
+    delete this.listeners[absolutePath];
   }
 
   // The Entry will either be a directory that just got removed
@@ -243,7 +243,7 @@ FSWatcher.prototype._watch = function(item, callback) {
   if (this.options.usePolling) {
     options.interval = this.enableBinaryInterval && isBinaryPath(basename) ?
       this.options.binaryInterval : this.options.interval;
-    listener = this.callbacks[absolutePath] = function(curr, prev) {
+    listener = this.listeners[absolutePath] = function(curr, prev) {
       if (curr.mtime.getTime() > prev.mtime.getTime()) {
         callback(item, curr);
       }
@@ -451,7 +451,7 @@ FSWatcher.prototype.add = function(files) {
 // Public: Remove all listeners from watched files.
 // Returns an instance of FSWatcher for chaning.
 FSWatcher.prototype.close = function() {
-  var callbacks = this.callbacks;
+  var listeners = this.listeners;
   if(this.closed) {
     return this;
   }
@@ -469,8 +469,8 @@ FSWatcher.prototype.close = function() {
     Object.keys(watched).forEach(function(directory) {
       return watched[directory].forEach(function(file) {
         var absolutePath = sysPath.resolve(directory, file)
-        fs.unwatchFile(absolutePath, callbacks[absolutePath]);
-        delete callbacks[absolutePath];
+        fs.unwatchFile(absolutePath, listeners[absolutePath]);
+        delete listeners[absolutePath];
       });
     });
   }


### PR DESCRIPTION
Using two (or more) instances of chokidar on the same file(s) with `usePolling=true` does not work properly. If one of those instances is closed, other instance does not watch files anymore:

``` javascript
var chokidar  = require('chokidar')
var watchFile = __filename;

var watchOnceAndClose = chokidar.watch(watchFile, { persistent:true })
watchOnceAndClose.on('change', function(file) {
  console.log('[watchOnceAndClose] event:change')
  console.log('[watchOnceAndClose] close()')
  watchOnceAndClose.close();
})

var watchAndContinue = chokidar.watch(watchFile, { persistent:true })
watchAndContinue.on('change', function() {
  console.log('[watchAndContinue] event:change')
})

process.on('exit', function() {
  console.log('!!! No more file to watch... exit')
})
```

Changes on the file, with `usePolling`, produce:

``` bash
[watchOnceAndClose] event:change
[watchOnceAndClose] close()
[watchAndContinue] event:change
!!! No more file to watch... exit
```

But this should produce (like without `usePolling`):

``` bash
[watchOnceAndClose] event:change
[watchOnceAndClose] close()
[watchAndContinue] event:change
[watchAndContinue] event:change
[watchAndContinue] event:change
[watchAndContinue] event:change
# ...
```

When `usePolling` is `true` chokidar use `fs.unwatchFile()` without the listener callback provided to `fs.watchFile()`. According to [fs.unwatchFile api](http://nodejs.org/api/fs.html#fs_fs_unwatchfile_filename_listener) _all listeners are removed_ if `fs.unwatchFile()` is called without the `listener` to remove.

This PR fix this issue by storing the listener of each watched file.
