### PR TITLE
index: rm tryCatch, canUseFsEvents

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,16 +5,14 @@ var os = require('os');
 var sysPath = require('path');
 
 var fsevents, recursiveReaddir;
-try {
-  fsevents = require('fsevents');
-  recursiveReaddir = require('recursive-readdir');
-} catch (error) {}
 
 var isWindows = os.platform() === 'win32';
-var canUseFsEvents = os.platform() === 'darwin' && !!fsevents;
+var isDarwn = os.platform() === 'darwin';
 
-// To disable FSEvents completely.
-// var canUseFsEvents = false;
+if (isDarwin) {
+  fsevents = require('fsevents');
+  recursiveReaddir = require('recursive-readdir');
+}
 
 // Binary file handling code.
 var _binExts = ['adp', 'au', 'mid', 'mp4a', 'mpga', 'oga', 's3m', 'sil', 'eol', 'dra', 'dts', 'dtshd', 'lvp', 'pya', 'ecelp4800', 'ecelp7470', 'ecelp9600', 'rip', 'weba', 'aac', 'aif', 'caf', 'flac', 'mka', 'm3u', 'wax', 'wma', 'wav', 'xm', 'flac', '3gp', '3g2', 'h261', 'h263', 'h264', 'jpgv', 'jpm', 'mj2', 'mp4', 'mpeg', 'ogv', 'qt', 'uvh', 'uvm', 'uvp', 'uvs', 'dvb', 'fvt', 'mxu', 'pyv', 'uvu', 'viv', 'webm', 'f4v', 'fli', 'flv', 'm4v', 'mkv', 'mng', 'asf', 'vob', 'wm', 'wmv', 'wmx', 'wvx', 'movie', 'smv', 'ts', 'bmp', 'cgm', 'g3', 'gif', 'ief', 'jpg', 'jpeg', 'ktx', 'png', 'btif', 'sgi', 'svg', 'tiff', 'psd', 'uvi', 'sub', 'djvu', 'dwg', 'dxf', 'fbs', 'fpx', 'fst', 'mmr', 'rlc', 'mdi', 'wdp', 'npx', 'wbmp', 'xif', 'webp', '3ds', 'ras', 'cmx', 'fh', 'ico', 'pcx', 'pic', 'pnm', 'pbm', 'pgm', 'ppm', 'rgb', 'tga', 'xbm', 'xpm', 'xwd', 'zip', 'rar', 'tar', 'bz2', 'eot', 'ttf', 'woff'];
@@ -72,7 +70,7 @@ function FSWatcher(_opts) {
   // Which is basically super fast watcher.
   if (opts.useFsEvents == null) opts.useFsEvents = !opts.usePolling;
   // If we can't use fs events, disable it in any case.
-  if (!canUseFsEvents) opts.useFsEvents = false;
+  opts.useFsEvents = isDarwin;
 
   if (opts.ignorePermissionErrors == null) opts.ignorePermissionErrors = false;
 


### PR DESCRIPTION
Removed tryCatch.
[Optimization-killers](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers)
[Best practices and gotchas with v8](https://github.com/joyent/node/wiki/Best-practices-and-gotchas-with-v8)
