### PR TITLE
Add support for files in $TMPDIR on OSX

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,7 +289,8 @@ function setFSEventsListener(path, callback, rawEmitter) {
   function filteredCallback(fullPath, flags, info) {
     if (
       fullPath === resolvedPath ||
-      !fullPath.indexOf(resolvedPath + sysPath.sep)
+      !fullPath.indexOf(resolvedPath + sysPath.sep) ||
+      fullPath === sysPath.join(sysPath.sep, 'private', resolvedPath)
     ) callback(fullPath, flags, info);
   }
 


### PR DESCRIPTION
The fullpath that is returned by fsevents includes `/private` in front of all files that exists inside of the $TMPDIR.  This was causing the evaluation in filteredCallback to always return false for any files in $TMPDIR.  This fix adds an extra boolean evaluation to test to allow for expected results.

Fixes #185
