### PR TITLE
check the real path for a watched parent

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -32,7 +32,7 @@ function setFSEventsListener(path, realPath, callback, rawEmitter) {
     // modifies `watchPath` to the parent path when it finds a match
     return Object.keys(FSEventsWatchers).some(function(watchedPath) {
       // condition is met when indexOf returns 0
-      if (!sysPath.resolve(watchPath).indexOf(sysPath.resolve(watchedPath))) {
+      if (!sysPath.resolve(realPath).indexOf(sysPath.resolve(watchedPath))) {
         watchPath = watchedPath;
         return true;
       }


### PR DESCRIPTION
This change creates fs instances for symlinks that link out to a file not in an already watched directory which is the parent of the symlink. Specifically this fixes watching files that have been npm link'd.

There might be a more efficient answer that creates an fs instance for the symlinked directory, but as far as i could tell the only reason my parent directory is currently being watched is because karma-browserify specifically includes the package.json as a watched file. That is, it doesn't seem to be something chokidar is doing intentionally.
