### PR TITLE
Fix parent watcher check in fsevents

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -32,7 +32,7 @@ function setFSEventsListener(path, realPath, callback, rawEmitter) {
     // modifies `watchPath` to the parent path when it finds a match
     return Object.keys(FSEventsWatchers).some(function(watchedPath) {
       // condition is met when indexOf returns 0
-      if (!realPath.indexOf(sysPath.resolve(watchedPath))) {
+      if (!realPath.indexOf(sysPath.resolve(watchedPath) + sysPath.sep)) {
         watchPath = watchedPath;
         return true;
       }


### PR DESCRIPTION
Fixes a bug that treats a path like `/a/b` as the parent of `/a/b-c`.
