### PR TITLE
remove moot require

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,6 @@ var NodeFsHandler = require('./nodefs-handler');
 var FsEventsHandler = require('./fsevents-handler');
 exports.isBinaryPath = require('./is-binary');
 
-var platform = require('os').platform();
-
 // Public: Main class.
 // Watches files & directories for changes.
 //
@@ -64,7 +62,7 @@ function FSWatcher(_opts) {
   // Use polling on Mac if not using fsevents.
   // Other platforms use non-polling fs.watch.
   if (undef('usePolling') && !opts.useFsEvents) {
-    opts.usePolling = platform === 'darwin';
+    opts.usePolling = process.platform === 'darwin';
   }
 
   // Editor atomic write normalization enabled by default with fs.watch


### PR DESCRIPTION
It's easier to just use `process.platform` which is the same thing.