### PR TITLE
Readme.md - add `windows passing` and `linux passing` to CI badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chokidar [![Mac/Linux Build Status](https://travis-ci.org/paulmillr/chokidar.svg?branch=master)](https://travis-ci.org/paulmillr/chokidar) [![Windows Build status](https://ci.appveyor.com/api/projects/status/jvv568xm6xsow034/branch/master?svg=true)](https://ci.appveyor.com/project/es128/chokidar/branch/master) [![Coverage Status](https://coveralls.io/repos/paulmillr/chokidar/badge.svg)](https://coveralls.io/r/paulmillr/chokidar)
+# Chokidar [![Mac/Linux Build Status](https://img.shields.io/travis/paulmillr/chokidar/master.svg?label=Mac%20OSX%20%26%20Linux)](https://travis-ci.org/paulmillr/chokidar) [![Windows Build status](https://img.shields.io/appveyor/ci/es128/chokidar/master.svg?label=Windows)](https://ci.appveyor.com/project/es128/chokidar/branch/master) [![Coverage Status](https://coveralls.io/repos/paulmillr/chokidar/badge.svg)](https://coveralls.io/r/paulmillr/chokidar)
 A neat wrapper around node.js fs.watch / fs.watchFile / fsevents.
 
 [![NPM](https://nodei.co/npm-dl/chokidar.png)](https://nodei.co/npm/chokidar/)


### PR DESCRIPTION
Given that this lib has gone to great efforts to ensure full support for both Windows + Unix-like systems, I believe that it should be clearer to users that this is the case.

Unless they are using app veyor themselves, the vast majority of your users will be none the wiser in regards to OS support as the app veyor logo will mean nothing to them.

This change is a simple one, but will make it crystal clear to all users that you take Windows support seriously.

Preview: 

http://f.cl.ly/items/2U151G0q3q2H0B3v253n/Screen%20Shot%202015-03-22%20at%2015.58.41.png