### PR TITLE
Add command line interface

### DIFF
--- a/cli/watch.js
+++ b/cli/watch.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+var childProcess = require('child_process');
+var Promise = require('bluebird');
+var _ = require('lodash');
+var minimatch = require('minimatch')
+var chokidar = require('../index');
+
+var defaultOpts = {
+    debounce: 400,
+    followSymlinks: false,
+    ignore: null,
+    polling: false,
+    pollInterval: 100,
+    pollIntervalBinary: 300
+};
+
+var argv = require('yargs')
+    .usage(
+        'Usage: $0 <command> <pattern> [options]\n\n' +
+        '<command>:\n' +
+        'Command to be executed when a change is detected.\n' +
+        'Needs to be surrounded with quotes when command contains spaces\n\n'+
+        '<pattern>:\n' +
+        'Glob pattern to specify files to be watched.\n' +
+        'Needs to be surrounded with quotes to prevent shell globbing.\n' +
+        'Guide to globs: https://github.com/isaacs/node-glob#glob-primer'
+    )
+    .example('$0 "npm run build-js" "**/*.js"', 'build when any .js file changes')
+    .demand(2)
+    .option('d', {
+        alias: 'debounce',
+        default: defaultOpts.debounce,
+        describe: 'Debounce timeout in ms for executing command',
+        type: 'number'
+    })
+    .option('s', {
+        alias: 'follow-symlinks',
+        default: defaultOpts.followSymlinks,
+        describe: 'When not set, only the symlinks themselves will be watched ' +
+                  'for changes instead of following the link references and ' +
+                  'bubbling events through the links path',
+        type: 'boolean'
+    })
+    .option('i', {
+        alias: 'ignore',
+        describe: 'Pattern for files which should be ignored. ' +
+                  'Needs to be surrounded with quotes to prevent shell globbing. ' +
+                  'The whole relative or absolute path is tested, not just filename'
+    })
+    .option('p', {
+        alias: 'polling',
+        describe: 'Whether to use fs.watchFile(backed by polling) instead of ' +
+                  'fs.watch. This might lead to high CPU utilization. ' +
+                  'It is typically necessary to set this to true to ' +
+                  'successfully watch files over a network, and it may be ' +
+                  'necessary to successfully watch files in other ' +
+                  'non-standard situations',
+        default: defaultOpts.polling,
+        type: 'boolean'
+    })
+    .option('poll-interval', {
+        describe: 'Interval of file system polling. Effective when --polling ' +
+                  'is set',
+        default: defaultOpts.pollInterval,
+        type: 'number'
+    })
+    .option('poll-interval-binary', {
+        describe: 'Interval of file system polling for binary files. ' +
+                  'Effective when --polling is set',
+        default: defaultOpts.pollIntervalBinary,
+        type: 'number'
+    })
+    .help('h')
+    .alias('h', 'help')
+    .alias('v', 'version')
+    .version(require('../package.json').version)
+    .argv;
+
+
+function main() {
+    var userOpts = getUserOpts(argv);
+
+    var opts = _.merge(defaultOpts, userOpts);
+    startWatching(opts);
+}
+
+function getUserOpts(argv) {
+    return {
+        command: argv._[0],
+        pattern: argv._[1],
+        debounce: argv.debounce,
+        followSymlinks: argv.followSymlinks,
+        ignore: argv.ignore,
+        polling: argv.polling,
+        pollInterval: argv.pollInterval,
+        pollIntervalBinary: argv.pollIntervalBinary
+    };
+}
+
+// Estimates spent working hours based on commit dates
+function startWatching(opts) {
+    var chokidarOpts = createChokidarOpts(opts);
+    var watcher = chokidar.watch(opts.pattern, chokidarOpts);
+
+    var debouncedRun = _.debounce(run, opts.debounce);
+    watcher.on('change', function(path, stats) {
+        // TODO: commands might be run concurrently
+        debouncedRun(opts.command);
+    });
+
+    watcher.on('error', function(error) {
+        console.error('Error:', error);
+        console.error(error.stack);
+    });
+
+    watcher.on('ready', function() {
+        console.log('Watching', '"' + opts.pattern + '" ..');
+    });
+}
+
+function createChokidarOpts(opts) {
+    var chokidarOpts = {
+        followSymlinks: opts.followSymlinks,
+        usePolling: opts.polling,
+        interval: opts.pollInterval,
+        binaryInterval: opts.pollIntervalBinary
+    };
+    if (opts.ignore) chokidarOpts.ignore = opts.ignore;
+
+    return chokidarOpts;
+}
+
+function run(cmd) {
+    var child;
+    var parts = cmd.split(' ');
+    try {
+        child = childProcess.spawn(_.head(parts), _.tail(parts));
+    } catch (e) {
+        return Promise.reject(e);
+    }
+
+    // TODO: Is there a chance of locking/waiting forever?
+    child.stdin.pipe(process.stdin);
+    child.stdout.pipe(process.stdout);
+    child.stderr.pipe(process.stderr);
+
+    return new Promise(function(resolve, reject) {
+        child.on('error', function(err) {
+            console.error('Error when executing', cmd);
+            console.error(err.stack);
+            reject(err);
+        });
+
+        child.on('close', function(exitCode) {
+            resolve(exitCode);
+        });
+    });
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "fsevents"
   ],
   "bin": {
-    "watch": "./cli/cli.js"
+    "watch": "./cli/watch.js"
   },
   "homepage": "https://github.com/paulmillr/chokidar",
   "author": "Paul Miller (http://paulmillr.com), Elan Shanker",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "file",
     "fsevents"
   ],
+  "bin": {
+    "watch": "./cli/cli.js"
+  },
   "homepage": "https://github.com/paulmillr/chokidar",
   "author": "Paul Miller (http://paulmillr.com), Elan Shanker",
   "repository": {
@@ -49,9 +52,13 @@
     "anymatch": "^1.1.0",
     "arrify": "^1.0.0",
     "async-each": "^0.1.5",
+    "bluebird": "^2.9.24",
     "glob-parent": "^1.0.0",
     "is-binary-path": "^1.0.0",
     "is-glob": "^1.1.3",
-    "readdirp": "^1.3.0"
+    "lodash": "^3.7.0",
+    "minimatch": "^2.0.4",
+    "readdirp": "^1.3.0",
+    "yargs": "^3.7.2"
   }
 }


### PR DESCRIPTION
Add cli too named `watch`. Argument parsing done with [yargs](https://github.com/bcoe/yargs). Adds a few dependencies.
```
➜  watch --help
Usage: watch <command> <pattern> [options]

<command>:
Command to be executed when a change is detected.
Needs to be surrounded with quotes when command contains spaces

<pattern>:
Glob pattern to specify files to be watched.
Needs to be surrounded with quotes to prevent shell globbing.
Guide to globs: https://github.com/isaacs/node-glob#glob-primer

Options:
  -d, --debounce          Debounce timeout in ms for executing command
                                                                  [default: 400]
  -s, --follow-symlinks   When not set, only the symlinks themselves will be
                          watched for changes instead of following the link
                          references and bubbling events through the links path
                                                     [boolean]  [default: false]
  -i, --ignore            Pattern for files which should be ignored. Needs to
                          be surrounded with quotes to prevent shell globbing.
                          The whole relative or absolute path is tested, not
                          just filename
  -p, --polling           Whether to use fs.watchFile(backed by polling)
                          instead of fs.watch. This might lead to high CPU
                          utilization. It is typically necessary to set this to
                          true to successfully watch files over a network, and
                          it may be necessary to successfully watch files in
                          other non-standard situations
                                                     [boolean]  [default: false]
  --poll-interval         Interval of file system polling. Effective when
                          --polling is set                        [default: 100]
  --poll-interval-binary  Interval of file system polling for binary files.
                          Effective when --polling is set         [default: 300]
  -h, --help              Show help
  -v, --version           Show version number

Examples:
  watch "npm run build-js" "**/*.js"    build when any .js file changes
```