### PR TITLE
Cleanup watcher's state after unwatching a path (fixes #289)

### DIFF
--- a/index.js
+++ b/index.js
@@ -430,7 +430,7 @@ FSWatcher.prototype.unwatch = function(paths) {
     if (this._closers[path]) {
       this._closers[path]();
       delete this._closers[path];
-      delete this._getWatchedDir(sysPath.dirname(path)).remove(sysPath.basename(path));
+      this._getWatchedDir(sysPath.dirname(path)).remove(sysPath.basename(path));
     } else {
       this._ignoredPaths[path] = true;
       if (path in this._watched) this._ignoredPaths[path + '/**/*'] = true;

--- a/index.js
+++ b/index.js
@@ -429,6 +429,8 @@ FSWatcher.prototype.unwatch = function(paths) {
   paths.forEach(function(path) {
     if (this._closers[path]) {
       this._closers[path]();
+      delete this._closers[path];
+      delete this._getWatchedDir(sysPath.dirname(path)).remove(sysPath.basename(path));
     } else {
       this._ignoredPaths[path] = true;
       if (path in this._watched) this._ignoredPaths[path + '/**/*'] = true;

--- a/test.js
+++ b/test.js
@@ -1234,6 +1234,23 @@ function runTests(options) {
           }));
       })();
     });
+    it('should watch paths the were unwatched and added again', function(done) {
+      var spy = sinon.spy();
+      var watchPaths = [getFixturePath('change.txt')];
+      watcher = chokidar.watch(watchPaths, options)
+        .on('all', spy)
+        .on('ready', d(function() {
+          watcher.unwatch(getFixturePath('change.txt'));
+          watcher.add(getFixturePath('change.txt'));
+
+          fs.writeFileSync(getFixturePath('change.txt'), 'c');
+          waitFor([spy], function() {
+            spy.should.have.been.calledWith('change', getFixturePath('change.txt'));
+            spy.should.have.been.calledOnce;
+            done();
+          });
+        }));
+    });
   });
   describe('close', function() {
     beforeEach(clean);


### PR DESCRIPTION
This should address the case with #289. In my working example it really worked after this change.

@es128, can you please check what's wrong with the test? It seems correct but it probably isn't, it doesn't pass in my env. As I said the change in `index.js` seems to indeed solve the issue, I double checked it with my production code. I also ran it under strace and it's now calling the `inotify_add_watcher` syscall again after remove, which was not the case before the fix. But the test is still failing :(