### PR TITLE
Use fsevents 0.3.7 to avoid segmentation faults

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sinon-chai": "^2.6.0"
   },
   "optionalDependencies": {
-    "fsevents": "^0.3.1"
+    "fsevents": "^0.3.7"
   },
   "dependencies": {
     "anymatch": "^1.1.0",


### PR DESCRIPTION
cf.

* https://github.com/strongloop/fsevents/pull/74
* https://github.com/strongloop/fsevents/issues/52