### PR TITLE
Workaround for iojs build issue using fsvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sinon-chai": "^2.6.0"
   },
   "optionalDependencies": {
-    "fsevents": "^0.3.7"
+    "fsevents": "^0.3.8"
   },
   "dependencies": {
     "anymatch": "^1.1.0",


### PR DESCRIPTION
Fixes errors installing with the latest iojs by updating to fixed fsevents package.