### PR TITLE
Added option to prevent path transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ symlinks themselves will be watched for changes instead of following
 the link references and bubbling events through the link's path.
 * `cwd` (no default). The base directory from which watch `paths` are to be
 derived. Paths emitted with events will be relative to this.
-* `preventPathTransformation` (default: `false`). When `true`, only the
-symlinks themselves will be watched for changes instead of following
-the link references and bubbling events through the link's path.
+* `preventPathTransformation` (default: `false`). When `true`, path is used literally
+without any transformation. It's useful when the name contains special characters
+like `*`, `(`, `)`, `{`, `}`...
 
 #### Performance
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ chokidar.watch('file', {
   ignoreInitial: false,
   followSymlinks: true,
   cwd: '.',
+  preventPathTransformation: false,
 
   usePolling: true,
   alwaysStat: false,
@@ -108,6 +109,7 @@ chokidar.watch('file', {
 
   ignorePermissionErrors: false,
   atomic: true
+
 });
 
 ```
@@ -140,6 +142,9 @@ symlinks themselves will be watched for changes instead of following
 the link references and bubbling events through the link's path.
 * `cwd` (no default). The base directory from which watch `paths` are to be
 derived. Paths emitted with events will be relative to this.
+* `preventPathTransformation` (default: `false`). When `true`, only the
+symlinks themselves will be watched for changes instead of following
+the link references and bubbling events through the link's path.
 
 #### Performance
 

--- a/index.js
+++ b/index.js
@@ -73,6 +73,9 @@ function FSWatcher(_opts) {
 
   if (undef('followSymlinks')) opts.followSymlinks = true;
 
+  // Prevent get non-magic path
+  if (undef('preventPathTransformation')) opts.preventPathTransformation = false;
+
   this._isntIgnored = function(path, stat) {
     return !this._isIgnored(path, stat);
   }.bind(this);
@@ -239,7 +242,7 @@ FSWatcher.prototype._isIgnored = function(path, stats) {
 // Returns object containing helpers for this path
 FSWatcher.prototype._getWatchHelpers = function(path, depth) {
   path = path.replace(/^\.[\/\\]/, '');
-  var watchPath = depth ? path : globparent(path);
+  var watchPath = depth || this.options.preventPathTransformation ? path : globparent(path);
   var hasGlob = watchPath !== path;
   var globFilter = hasGlob ? anymatch(path) : false;
 


### PR DESCRIPTION
It fixes some issues like:
* Issue with watching directory with name including glob characters https://github.com/paulmillr/chokidar/issues/300
* chokidar doesn't notice changes under weird path https://github.com/paulmillr/chokidar/issues/336
* Folder with parenthesis in the name can't be watched https://github.com/paulmillr/chokidar/issues/344