### PR TITLE
Add waitWriteFinish option

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ subdirectories will be traversed.
   polling for binary files.
   ([see list of binary extensions](https://github.com/sindresorhus/binary-extensions/blob/master/binary-extensions.json))
 
+#### Waiting for write operation to finish
+* `waitWriteFinish` (default: `false`).
+The `add` event will fire when a file first appear on disk, before the entire
+file has been written. Furthermore, in some cases some `change` events will be emitted while the file is being written.
+In some cases, especially when watching for large files there will be a need to 
+wait for the write operation to finish before responding to the file creation.
+Setting `waitWriteFinish` to `true` will poll a newly created file size, holding 
+its `add` and `change` events until its size will not change for a configurable amount of time.
+* `writeFinishThreshold` (default: 2000).
+Amount of time in milliseconds for a file size to remain constant before emitting its 
+`add` event. Unfortunately this duration is heavily dependent on OS and local hardware.
+For accurate detection this parameter should be relatively high, making file watching much less
+responsive. Use with cation. 
+
 #### Errors
 * `ignorePermissionErrors` (default: `false`). Indicates whether to watch files
 that don't have read permissions if possible. If watching fails due to `EPERM`

--- a/README.md
+++ b/README.md
@@ -168,18 +168,34 @@ subdirectories will be traversed.
   ([see list of binary extensions](https://github.com/sindresorhus/binary-extensions/blob/master/binary-extensions.json))
 
 #### Waiting for write operation to finish
-* `waitWriteFinish` (default: `false`).
+* `awaitWriteFinish` (default: `false`).
 The `add` event will fire when a file first appear on disk, before the entire
 file has been written. Furthermore, in some cases some `change` events will be emitted while the file is being written.
 In some cases, especially when watching for large files there will be a need to 
 wait for the write operation to finish before responding to the file creation.
-Setting `waitWriteFinish` to `true` will poll a newly created file size, holding 
-its `add` and `change` events until its size will not change for a configurable amount of time.
-* `writeFinishThreshold` (default: 2000).
-Amount of time in milliseconds for a file size to remain constant before emitting its 
-`add` event. Unfortunately this duration is heavily dependent on OS and local hardware.
+Setting `awaitWriteFinish` to `true` will poll a newly created file size, holding 
+its `add` and `change` events until the size does not change for a configurable amount of time.
+The appropriate duration setting is heavily dependent on the OS and hardware.
 For accurate detection this parameter should be relatively high, making file watching much less
 responsive. Use with cation. 
+* `awaitWriteFinish.stabilityThreshold` (default: 2000). Amount of time in milliseconds for a file size to remain constant before emitting its 
+`add` event. 
+* `awaitWriteFinish.pollInterval` (default: 100). Interval of file size polling.
+
+```js
+// use awaitWriteFinish with default parameters
+chokidar.watch('file', {
+  awaitWriteFinish: true
+});
+
+// change awaitWriteFinish parameters
+chokidar.watch('file', {
+  awaitWriteFinish: {
+    stabilityThreshold: 5000,
+    pollInterval: 200
+  }
+});
+```
 
 #### Errors
 * `ignorePermissionErrors` (default: `false`). Indicates whether to watch files

--- a/index.js
+++ b/index.js
@@ -73,6 +73,11 @@ function FSWatcher(_opts) {
 
   if (undef('followSymlinks')) opts.followSymlinks = true;
 
+  if (undef('waitWriteFinish')) opts.waitWriteFinish = false;
+  if (undef('writeFinishThreshold')) opts.writeFinishThreshold = 2000;
+
+  if (opts.waitWriteFinish) this._pendingWrites = Object.create(null);
+
   this._isntIgnored = function(path, stat) {
     return !this._isIgnored(path, stat);
   }.bind(this);
@@ -111,6 +116,9 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
   if (val3 !== undefined) args.push(val1, val2, val3);
   else if (val2 !== undefined) args.push(val1, val2);
   else if (val1 !== undefined) args.push(val1);
+
+  if ((this.options.waitWriteFinish && this._pendingWrites[path])) return this;
+
   if (this.options.atomic) {
     if (event === 'unlink') {
       this._pendingUnlinks[path] = args;
@@ -128,6 +136,7 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
     }
   }
 
+
   if (event === 'change') {
     if (!this._throttle('change', path, 50)) return this;
   }
@@ -137,7 +146,19 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
     if (event !== 'error') this.emit.apply(this, ['all'].concat(args));
   }.bind(this);
 
-  if (
+  if (this.options.waitWriteFinish && event === 'add') {
+    this._awaitWriteFinish(path, this.options.writeFinishThreshold, function(err, stats){
+      if(err){
+        event = args[0] = 'error';
+        args[1] = err;
+        emitEvent();
+      } else if(stats){
+        // if stats doesn't exist the file must have been deleted
+        args.push(stats);
+        emitEvent();        
+      }
+    });
+  } else if (
     this.options.alwaysStat && val1 === undefined &&
     (event === 'add' || event === 'addDir' || event === 'change')
   ) {
@@ -193,6 +214,51 @@ FSWatcher.prototype._throttle = function(action, path, timeout) {
   throttled[path] = {timeoutObject: timeoutObject, clear: clear};
   return throttled[path];
 };
+
+// Private method: Awaits write operation to finish
+//
+// * path    - string, path being acted upon
+// * threshold - int, time in milliseconds a file size must be fixed before acknowledgeing write operation is finished
+// * callback - function, callback to call when write operation is finished 
+// Polls a newly created file for size variations. When files size does not change for 'threshold'
+// milliseconds calls callback.
+FSWatcher.prototype._awaitWriteFinish = function(path, threshold, callback){
+  var timeoutHandler;
+
+  var awaitWriteFinish = function(prevStat){
+    fs.stat(path, function(err, curStat){
+      if(err){
+        // if the file have been erased, the file entry in _pendingWrites will
+        // be deleted in the unlink event.
+        if(err.code == 'ENOENT') return;
+
+        return callback(err);
+      } 
+        
+      var now = new Date();
+      if(this._pendingWrites[path] === undefined){
+        this._pendingWrites[path] = {
+          creationTime: now,
+          cancelWait: function(){
+            delete this._pendingWrites[path];
+            clearTimeout(timeoutHandler);
+            return callback();
+          }.bind(this)
+        }
+        return timeoutHandler = setTimeout(awaitWriteFinish.bind(this, curStat), this.options.interval);
+      }
+
+      if(curStat.size == prevStat.size && now - this._pendingWrites[path].creationTime > threshold){
+        delete this._pendingWrites[path];
+        callback(null, curStat);
+      } else{
+        return timeoutHandler = setTimeout(awaitWriteFinish.bind(this, curStat), this.options.interval);
+      }
+    }.bind(this));
+  }.bind(this);
+
+  awaitWriteFinish(); 
+}
 
 // Private method: Determines whether user has asked to ignore this path
 //
@@ -367,6 +433,12 @@ FSWatcher.prototype._remove = function(directory, item) {
   var parent = this._getWatchedDir(directory);
   var wasTracked = parent.has(item);
   parent.remove(item);
+
+  // If we wait for this file to be fully written, cancel the wait.
+  if(this.options.waitWriteFinish && this._pendingWrites[path]) {
+    this._pendingWrites[path].cancelWait();
+    return;
+  }
 
   // The Entry will either be a directory that just got removed
   // or a bogus entry to a file, in either case we have to remove it

--- a/test.js
+++ b/test.js
@@ -670,7 +670,7 @@ function runTests(options) {
     });
     it('should recognize changes following symlinked dirs', function(done) {
       var spy = sinon.spy(function changeSpy(){});
-      d(function(){
+      d(function() {
         watcher = chokidar.watch(linkedDir, options)
           .on('change', spy)
           .on('ready', function() {
@@ -790,7 +790,7 @@ function runTests(options) {
           d(function() {
             watcher = chokidar.watch(fixturesPath, options)
               .on('addDir', spy)
-              .on('ready', function(){
+              .on('ready', function() {
                 spy.should.have.been.calledWith(fixturesPath);
                 spy.should.have.been.calledWith(getFixturePath('subdir'));
                 spy.should.have.been.calledWith(getFixturePath('subdir/dir'));
@@ -1223,10 +1223,18 @@ function runTests(options) {
         });
       });
     });
-    describe('waitWriteFinish', function() {
+    describe('awaitWriteFinish', function() {
       beforeEach(function() { 
-        options.waitWriteFinish = true; 
-        options.writeFinishThreshold = 1000;
+        options.awaitWriteFinish = {
+          stabilityThreshold: 1000
+        }; 
+      });
+      it('should use default options if none givven', function() {
+        options.awaitWriteFinish = true;
+        
+        var watcher = stdWatcher();
+        expect(watcher.options.awaitWriteFinish.pollInterval).to.equal(100);
+        expect(watcher.options.awaitWriteFinish.stabilityThreshold).to.equal(2000);
       });
       it('should not emit add event before a file is fully written', function(done) {
         var spy = sinon.spy();
@@ -1235,7 +1243,7 @@ function runTests(options) {
           .on('all', spy)
           .on('ready', function() {
             fs.writeFileSync(testPath, 'hello');
-            dd(function(){
+            dd(function() {
               spy.should.not.have.been.calledWith('add');
               done();
             })();
@@ -1248,7 +1256,7 @@ function runTests(options) {
           .on('all', spy)
           .on('ready', function() {
             fs.writeFileSync(testPath, 'hello');
-            dd(function(){
+            dd(function() {
               spy.should.not.have.been.calledWith('add');
               setTimeout(function() {
                 spy.should.have.been.calledWith('add');
@@ -1280,13 +1288,13 @@ function runTests(options) {
         stdWatcher()
           .on('all', spy)
           .on('change', changeSpy)
-          .on('ready', function(){
+          .on('ready', function() {
             fs.writeFileSync(testPath, 'hello');
             dd(function() {
               spy.should.not.have.been.calledWith('add', testPath);
               setTimeout(function() {
                 fs.writeFileSync(testPath, 'edit');
-                waitFor([changeSpy], function(){
+                waitFor([changeSpy], function() {
                   changeSpy.should.have.been.calledWith(testPath);
                   done();
                 });


### PR DESCRIPTION
The `add` event will fire when a file first appear on disk, before the entire file has been written. Furthermore, in some cases some `change` events will be emitted while the file is being written.
In some cases, especially when watching for large files there will be a need to wait for the write operation to finish before responding to the file creation.

Current event throttling is insufficient to handle this case. For a large enough file, or slow enough write, change event might be emitted for several seconds after the file have appeared.

Setting `waitWriteFinish` to `true` will poll a newly created file size, holding its `add` and `change` events until its size will not change for `writeFinishThreshold` amount of time.

**Note**
Some tests failed to pass for me. I've patched them in the first commit, but I'm not confident in the fix. Please advise.
Fix might be related to issue #273 or issue #258