### PR TITLE
Update deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ FSWatcher.prototype._isIgnored = function(path, stats) {
 // Returns object containing helpers for this path
 FSWatcher.prototype._getWatchHelpers = function(path, depth) {
   path = path.replace(/^\.[\/\\]/, '');
-  var watchPath = depth ? path : globparent(path);
+  var watchPath = depth || !isglob(path) ? path : globparent(path);
   var hasGlob = watchPath !== path;
   var globFilter = hasGlob ? anymatch(path) : false;
 

--- a/package.json
+++ b/package.json
@@ -38,16 +38,16 @@
     "sinon-chai": "^2.6.0"
   },
   "optionalDependencies": {
-    "fsevents": "^0.3.8"
+    "fsevents": "^1.0.0"
   },
   "dependencies": {
     "anymatch": "^1.1.0",
     "arrify": "^1.0.0",
     "async-each": "^0.1.5",
-    "glob-parent": "^1.0.0",
+    "glob-parent": "^2.0.0",
     "is-binary-path": "^1.0.0",
-    "is-glob": "^1.1.3",
+    "is-glob": "^2.0.0",
     "path-is-absolute": "^1.0.0",
-    "readdirp": "^1.3.0"
+    "readdirp": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "lib/"
   ],
   "devDependencies": {
-    "chai": "^1.9.2",
+    "chai": "^3.2.0",
     "coveralls": "^2.11.2",
-    "istanbul": "^0.3.5",
+    "istanbul": "^0.3.20",
     "mocha": "^2.0.0",
     "sinon": "^1.10.3",
     "sinon-chai": "^2.6.0"


### PR DESCRIPTION
Had to make a small change to account for https://github.com/es128/glob-parent/pull/4

The bump to fsevents@1.0.0 ought to be a significant improvement for users - making installs much quicker and smoother, owing to https://github.com/strongloop/fsevents/pull/59

Once merged, intend to publish as 1.1.0