### PR TITLE
Recreating deleted directory doesn't trigger event

### DIFF
--- a/index.js
+++ b/index.js
@@ -453,6 +453,11 @@ FSWatcher.prototype._remove = function(directory, item) {
     return;
   }
 
+  // Avoid conflicts if we later create another directory with the same name
+  if (isDirectory) {
+    this.unwatch(path);
+  }
+
   // The Entry will either be a directory that just got removed
   // or a bogus entry to a file, in either case we have to remove it
   delete this._watched[path];


### PR DESCRIPTION
If we add a watch on directory A, mkdir A/B, rm -r A/B, mkdir A/B,
mkdir A/B/C, no event comes from fs.watch on creation of A/B/C

Encountered on Ubuntu 14.04.3 LTS, Linux 3.16.0-50-generic x86_64