### PR TITLE
Pull request #378 + test

### DIFF
--- a/index.js
+++ b/index.js
@@ -459,6 +459,11 @@ FSWatcher.prototype._remove = function(directory, item) {
   delete this._watched[fullPath];
   var eventName = isDirectory ? 'unlinkDir' : 'unlink';
   if (wasTracked && !this._isIgnored(path)) this._emit(eventName, path);
+
+  // Avoid conflicts if we later create another directory with the same name
+  if (isDirectory && !this.options.usePolling) {
+    this.unwatch(path);
+  }
 };
 
 // Public method: Adds paths to be watched on an existing FSWatcher instance


### PR DESCRIPTION
If we add a watch on directory A, mkdir A/B, rm -r A/B, mkdir A/B,
mkdir A/B/C, no event comes from fs.watch on creation of A/B/C

Encountered on Ubuntu 14.04.3 LTS, Linux 3.16.0-50-generic x86_64