### PR TITLE
When adding a previously-deleted file, emit 'add', not 'change'

### DIFF
--- a/index.js
+++ b/index.js
@@ -460,8 +460,8 @@ FSWatcher.prototype._remove = function(directory, item) {
   var eventName = isDirectory ? 'unlinkDir' : 'unlink';
   if (wasTracked && !this._isIgnored(path)) this._emit(eventName, path);
 
-  // Avoid conflicts if we later create another directory with the same name
-  if (isDirectory && !this.options.usePolling) {
+  // Avoid conflicts if we later create another file with the same name
+  if (!this.options.useFsEvents) {
     this.unwatch(path);
   }
 };

--- a/test.js
+++ b/test.js
@@ -245,6 +245,32 @@ function runTests(options) {
           });
         }));
     });
+    it('should emit `add`, but not `change` when previously deleted file is re-added', function(done) {
+      var unlinkSpy = sinon.spy(function unlink(){});
+      var addSpy = sinon.spy(function add(){});
+      var changeSpy = sinon.spy(function change(){});
+      var testPath = getFixturePath('add.txt');
+      fs.writeFileSync(testPath, 'hello');
+      watcher
+        .on('unlink', unlinkSpy)
+        .on('add', addSpy)
+        .on('change', changeSpy)
+        .on('ready', d(function() {
+          unlinkSpy.should.not.have.been.called;
+          addSpy.should.not.have.been.called;
+          changeSpy.should.not.have.been.called;
+          fs.unlinkSync(testPath);
+          waitFor([unlinkSpy], d(function() {
+            unlinkSpy.should.have.been.calledWith(testPath);
+            fs.writeFileSync(testPath, 'b');
+            waitFor([addSpy], d(function() {
+              addSpy.should.have.been.calledWith(testPath);
+              changeSpy.should.not.have.been.called;
+              done();
+            }));
+          }));
+        }));
+    });
     it('should not emit `unlink` for previously moved files', function(done) {
       var unlinkSpy = sinon.spy(function unlink(){});
       var testPath = getFixturePath('change.txt');


### PR DESCRIPTION
Turns out #379 is an issue for files as well as directories, but manifests differently.