### PR TITLE
Make awf and cwd options compatibles

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,8 +232,13 @@ FSWatcher.prototype._throttle = function(action, path, timeout) {
 FSWatcher.prototype._awaitWriteFinish = function(path, threshold, callback) {
   var timeoutHandler;
 
+  var fullPath = path;
+  if (this.options.cwd && !isAbsolute(path)) {
+    fullPath = sysPath.join(this.options.cwd, path);
+  }
+
   (function awaitWriteFinish (prevStat) {
-    fs.stat(path, function(err, curStat) {
+    fs.stat(fullPath, function(err, curStat) {
       if (err) {
         delete this._pendingWrites[path];
         if (err.code == 'ENOENT') return;

--- a/test.js
+++ b/test.js
@@ -1392,6 +1392,21 @@ function runTests(options) {
             })();
           });
       });
+      it('should be compatible with the cwd option', function(done) {
+        var spy = sinon.spy();
+        var testPath = getFixturePath('awf_cwd/awf_cwd.txt');
+        options.cwd = sysPath.dirname(testPath);
+        fs.mkdirSync(options.cwd);
+        stdWatcher()
+          .on('all', spy)
+          .on('ready', function() {
+            fs.writeFileSync(testPath, 'hello');
+            setTimeout(function() {
+              spy.should.have.been.calledWith('add');
+              done();
+            }, 1100);
+          });
+      });
     });
   });
   describe('unwatch', function() {

--- a/test.js
+++ b/test.js
@@ -47,6 +47,8 @@ function rmFixtures() {
   try { fs.rmdirSync(getFixturePath('subdir2/dir')); } catch(err) {}
   try { fs.rmdirSync(getFixturePath('subdir2')); } catch(err) {}
   try { fs.rmdirSync(getFixturePath('subdir')); } catch(err) {}
+  try { fs.unlinkSync(getFixturePath('awf_cwd/awf_cwd.txt')); } catch(err) {}
+  try { fs.rmdirSync(getFixturePath('awf_cwd')); } catch(err) {}
 }
 
 after(function() {


### PR DESCRIPTION
Before this commit, when `awaitWriteFinish` and `cwd` options were enabled at the same time and `cwd` was not the current directory, no `add` events were fired. It was because the `fs.stat` failed in `awaitWriteFinish`.