### PR TITLE
Expand awaitWriteFinish to hold 'change' events for existing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,8 @@ By default, the `add` event will fire when a file first appear on disk, before
 the entire file has been written. Furthermore, in some cases some `change`
 events will be emitted while the file is being written.
 In some cases, especially when watching for large files there will be a need to
-wait for the write operation to finish before responding to the file creation.
-Setting `awaitWriteFinish` to `true` (or a truthy value) will poll a newly
-created file size, holding its `add` and `change` events until the size does not
+wait for the write operation to finish before responding to a file creation or modification.
+Setting `awaitWriteFinish` to `true` (or a truthy value) will poll file size, holding its `add` and `change` events until the size does not
 change for a configurable amount of time. The appropriate duration setting is
 heavily dependent on the OS and hardware. For accurate detection this parameter
 should be relatively high, making file watching much less responsive.

--- a/index.js
+++ b/index.js
@@ -165,16 +165,12 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
     }
   }
 
-  if (event === 'change') {
-    if (!this._throttle('change', path, 50)) return this;
-  }
-
   var emitEvent = function() {
     this.emit.apply(this, args);
     if (event !== 'error') this.emit.apply(this, ['all'].concat(args));
   }.bind(this);
 
-  if (awf && event === 'add' && this._readyEmitted) {
+  if (awf && (event === 'add' || event === 'change') && this._readyEmitted) {
     var awfEmit = function(err, stats) {
       if (err) {
         event = args[0] = 'error';
@@ -188,7 +184,14 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
     };
 
     this._awaitWriteFinish(path, awf.stabilityThreshold, awfEmit);
-  } else if (
+    return this;
+  }
+
+  if (event === 'change') {
+    if (!this._throttle('change', path, 50)) return this;
+  }
+
+  if (
     this.options.alwaysStat && val1 === undefined &&
     (event === 'add' || event === 'addDir' || event === 'change')
   ) {

--- a/test.js
+++ b/test.js
@@ -1393,6 +1393,34 @@ function runTests(options) {
             });
           }.bind(this));
       });
+      it('should not emit change event before an existing file is fully updated', function(done) {
+
+        var spy = sinon.spy();
+        var testPath = getFixturePath('change.txt');
+        stdWatcher()
+          .on('all', spy)
+          .on('ready', function() {
+            fs.writeFileSync(testPath, 'hello');
+            wait(300, function() {
+              spy.should.not.have.been.calledWith('change', testPath);
+              done();
+            });
+          }.bind(this));
+      });
+      it('should wait for an existing file to be fully updated before emiting the change event', function(done) {
+
+        var spy = sinon.spy();
+        var testPath = getFixturePath('change.txt');
+        stdWatcher()
+          .on('all', spy)
+          .on('ready', function() {
+            fs.writeFileSync(testPath, 'hello');
+            wait(700, function() {
+              spy.should.have.been.calledWith('change', testPath);
+              done();
+            });
+          }.bind(this));
+      });
       it('should emit change event after the file is fully written', function(done) {
         var spy = sinon.spy();
         var changeSpy = sinon.spy();
@@ -1418,13 +1446,13 @@ function runTests(options) {
           .on('all', spy)
           .on('ready', function() {
             fs.writeFileSync(testPath, 'hello');
-            d(function() {
+            wait(400, function() {
               fs.unlinkSync(testPath);
-              wait(700, function() {
+              wait(400, function() {
                 spy.should.not.have.been.calledWith(sinon.match.string, testPath);
                 done();
               });
-            })();
+            });
           });
       });
       it('should be compatible with the cwd option', function(done) {


### PR DESCRIPTION
Fix issue #381