### PR TITLE
Fix bug with dir events under glob patterns

### DIFF
--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -330,12 +330,14 @@ function(entry, directory, path, item) {
 // Returns close function for the watcher instance
 NodeFsHandler.prototype._handleDir =
 function(dir, stats, initialAdd, depth, target, wh, callback) {
-  if (!(initialAdd && this.options.ignoreInitial) && !target && !wh.hasGlob) {
-    this._emit('addDir', dir, stats);
+  var parentDir = this._getWatchedDir(sysPath.dirname(dir));
+  var tracked = parentDir.has(sysPath.basename(dir));
+  if (!(initialAdd && this.options.ignoreInitial) && !target && !tracked) {
+    if (!wh.hasGlob || wh.globFilter(dir)) this._emit('addDir', dir, stats);
   }
 
-  // ensure dir is tracked
-  this._getWatchedDir(sysPath.dirname(dir)).add(sysPath.basename(dir));
+  // ensure dir is tracked (harmless if redundant)
+  parentDir.add(sysPath.basename(dir));
   this._getWatchedDir(dir);
 
   var read = function(directory, initialAdd, done) {
@@ -436,6 +438,7 @@ function(path, initialAdd, priorWh, depth, target, callback) {
   var wh = this._getWatchHelpers(path, depth);
   if (!wh.hasGlob && priorWh) {
     wh.hasGlob = priorWh.hasGlob;
+    wh.globFilter = priorWh.globFilter;
     wh.filterPath = priorWh.filterPath;
     wh.filterDir = priorWh.filterDir;
   }


### PR DESCRIPTION
Bumped into this while working on a fix for #293. In `nodefs-handler`, the `addDir` event was being suppressed any time a glob was in use, even though there are situations where dir paths should match.

@paulmillr @alexpusch 

Resolves #337 