### PR TITLE
Fix unwatch

### DIFF
--- a/test.js
+++ b/test.js
@@ -1581,6 +1581,27 @@ function runTests(baseopts) {
           })();
         }));
     });
+    it('should unwatch paths that are relative to options.cwd', function(done) {
+      options.cwd = fixturesPath;
+      var spy = sinon.spy();
+      watcher = chokidar.watch('.', options)
+        .on('all', spy)
+        .on('ready', function() {
+          watcher.unwatch(['subdir', getFixturePath('unlink.txt')]);
+          w(function() {
+            fs.unlink(getFixturePath('unlink.txt'), simpleCb);
+            fs.writeFile(getFixturePath('subdir/add.txt'), Date.now(), simpleCb);
+            fs.writeFile(getFixturePath('change.txt'), Date.now(), simpleCb);
+          })();
+          waitFor([spy], w(function() {
+            spy.should.have.been.calledWith('change', 'change.txt');
+            spy.should.not.have.been.calledWith('add');
+            spy.should.not.have.been.calledWith('unlink');
+            if (!osXFsWatch010) spy.should.have.been.calledOnce;
+            done();
+          }, 300));
+        });
+    });
   });
   describe('close', function() {
     it('should ignore further events on close', function(done) {


### PR DESCRIPTION
Corrected the following problems:

1. Did not working properly with paths depending on being relative to the `options.cwd` setting
2. Relative path handling wasn't really working, but this was masked by the fallback to ignoring based on resolved absolute paths
3. Unwatching was previously acheived by either closing the underlying watcher, or adding the path to be ignored. When the former method was used on subdirs under `fs.watch` or `fs.watchFIle` modes, the paths had the opportunity to be re-introduced unexpectedly any time the parent dir was checked again, so it's actually necessary to do both watcher closing (when applicable) and ignoring to prevent this.

Resolves #374 