### PR TITLE
Added inherits to enable ES6 subclassing of FSWatcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var anymatch = require('anymatch');
 var globParent = require('glob-parent');
 var isGlob = require('is-glob');
 var isAbsolute = require('path-is-absolute');
+var inherits = require('inherits');
 
 var NodeFsHandler = require('./lib/nodefs-handler');
 var FsEventsHandler = require('./lib/fsevents-handler');
@@ -51,6 +52,7 @@ var isString = function(thing) {
 //    .on('all', function(event, path) {console.log(path, ' emitted ', event);})
 //
 function FSWatcher(_opts) {
+  EventEmitter.call(this);
   var opts = {};
   // in case _opts that is passed in is a frozen object
   if (_opts) for (var opt in _opts) opts[opt] = _opts[opt];
@@ -125,7 +127,7 @@ function FSWatcher(_opts) {
   Object.freeze(opts);
 }
 
-FSWatcher.prototype = Object.create(EventEmitter.prototype);
+inherits(FSWatcher, EventEmitter);
 
 // Common helpers
 // --------------

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "anymatch": "^1.3.0",
     "async-each": "^0.1.6",
     "glob-parent": "^2.0.0",
+    "inherits": "^2.0.1",
     "is-binary-path": "^1.0.0",
     "is-glob": "^2.0.0",
     "path-is-absolute": "^1.0.0",


### PR DESCRIPTION
I've been using FSWatcher directly in a couple of places and needed to monkey patch it for subclassing in ES6.
