### PR TITLE
Fix the emitted stats when using awf

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,11 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
         emitEvent();
       } else if (stats) {
         // if stats doesn't exist the file must have been deleted
-        args.push(stats);
+        if (args.length > 2) {
+          args[2] = stats;
+        } else {
+          args.push(stats);
+        }
         emitEvent();
       }
     };

--- a/test.js
+++ b/test.js
@@ -1417,6 +1417,22 @@ function runTests(baseopts) {
             });
           });
       });
+      it('should emit with the final stats', function(done) {
+        var spy = sinon.spy();
+        var testPath = getFixturePath('add.txt');
+        stdWatcher()
+          .on('all', spy)
+          .on('ready', function() {
+            fs.writeFile(testPath, 'hello ', w(function() {
+              fs.appendFileSync(testPath, 'world!');
+            }, 300));
+            waitFor([spy], function() {
+              spy.should.have.been.calledWith('add', testPath);
+              expect(spy.args[0][2].size).to.equal(12);
+              done();
+            });
+          });
+      });
       it('should not emit change event while a file has not been fully written', function(done) {
         var spy = sinon.spy();
         var testPath = getFixturePath('add.txt');


### PR DESCRIPTION
When using the awaitWriteFinish options, the stats were emitted for the file as it was first detected, not as it is when the event if fired.