### PR TITLE
readme: remove gulp as a chokidar user

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Node.js `fs.watchFile`:
 Chokidar resolves these problems.
 
 Initially made for [brunch](http://brunch.io) (an ultra-swift web app build tool), it is now used in
-[gulp](https://github.com/gulpjs/gulp/),
 [karma](http://karma-runner.github.io),
 [PM2](https://github.com/Unitech/PM2),
 [browserify](http://browserify.org/),


### PR DESCRIPTION
`gulp@3.9.0` requires `"vinyl-fs": "^0.3.0"` which installs `vinyl-fs@0.3.14` which uses gaze@0.5.2

```
$ npm-remote-ls vinyl-fs@0.3.14 | grep gaze
   │  └─ gaze@0.5.2
```

Newest version of vinyl-fs doesn't even use gaze nor chokidar, just glob-stream.