### PR TITLE
Allow user to set debounce delay for atomic option

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,9 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
           this.emit.apply(this, ['all'].concat(this._pendingUnlinks[path]));
           delete this._pendingUnlinks[path];
         }.bind(this));
-      }.bind(this), 100);
+      }.bind(this), typeof this.options.atomic === "number"
+        ? this.options.atomic
+        : 100);
       return this;
     } else if (event === 'add' && this._pendingUnlinks[path]) {
       event = args[0] = 'change';


### PR DESCRIPTION
For me (on an i3 laptop with good old 5400rpm hard drive), `atomic` only works with a delay of 500ms. I've added a way to configure it by setting `atomic` to a number rather than `true`.