### PR TITLE
take new events into account for awaitWriteFinish

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,19 +299,20 @@ FSWatcher.prototype._awaitWriteFinish = function(path, threshold, event, awfEmit
     }.bind(this));
   }.bind(this));
 
-  if (this._pendingWrites[path]) this._pendingWrites[path].cancelWait();
-
-  this._pendingWrites[path] = {
-    lastChange: now,
-    cancelWait: function() {
-      delete this._pendingWrites[path];
-      clearTimeout(timeoutHandler);
-    }.bind(this)
-  };
-  timeoutHandler = setTimeout(
-    awaitWriteFinish.bind(this),
-    this.options.awaitWriteFinish.pollInterval
-  );
+  if (!(path in this._pendingWrites)) {
+    this._pendingWrites[path] = {
+      lastChange: now,
+      cancelWait: function() {
+        delete this._pendingWrites[path];
+        clearTimeout(timeoutHandler);
+        return event;
+      }.bind(this)
+    };
+    timeoutHandler = setTimeout(
+      awaitWriteFinish.bind(this),
+      this.options.awaitWriteFinish.pollInterval
+    );
+  }
 };
 
 // Private method: Determines whether user has asked to ignore this path

--- a/index.js
+++ b/index.js
@@ -148,7 +148,10 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
   else if (val1 !== undefined) args.push(val1);
 
   var awf = this.options.awaitWriteFinish;
-  if (awf && this._pendingWrites[path]) return this;
+  if (awf && this._pendingWrites[path]) {
+    this._pendingWrites[path].lastChange = new Date();
+    return this;
+  }
 
   if (this.options.atomic) {
     if (event === 'unlink') {

--- a/index.js
+++ b/index.js
@@ -299,20 +299,19 @@ FSWatcher.prototype._awaitWriteFinish = function(path, threshold, event, awfEmit
     }.bind(this));
   }.bind(this));
 
-  if (!(path in this._pendingWrites)) {
-    this._pendingWrites[path] = {
-      lastChange: now,
-      cancelWait: function() {
-        delete this._pendingWrites[path];
-        clearTimeout(timeoutHandler);
-        return event;
-      }.bind(this)
-    };
-    timeoutHandler = setTimeout(
-      awaitWriteFinish.bind(this),
-      this.options.awaitWriteFinish.pollInterval
-    );
-  }
+  if (this._pendingWrites[path]) this._pendingWrites[path].cancelWait();
+
+  this._pendingWrites[path] = {
+    lastChange: now,
+    cancelWait: function() {
+      delete this._pendingWrites[path];
+      clearTimeout(timeoutHandler);
+    }.bind(this)
+  };
+  timeoutHandler = setTimeout(
+    awaitWriteFinish.bind(this),
+    this.options.awaitWriteFinish.pollInterval
+  );
 };
 
 // Private method: Determines whether user has asked to ignore this path


### PR DESCRIPTION
I was having issues when listening to a local path which is mounted as a samba share for others to copy files. The problem is that samba reserves the filesize for that transfer and the stats function returns always the full size even with 1% of the transfer completed.

I understand this solution might not be suitable for some other users where the file size is the key point. Probably another config option instead.