### PR TITLE
awf not to require ready event

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,6 @@ function FSWatcher(_opts) {
   this._emitReady = function() {
     if (++readyCalls >= this._readyCount) {
       this._emitReady = Function.prototype;
-      this._readyEmitted = true;
       // use process.nextTick to allow time for listener to be bound
       process.nextTick(this.emit.bind(this, 'ready'));
     }

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
     if (event !== 'error') this.emit.apply(this, ['all'].concat(args));
   }.bind(this);
 
-  if (awf && (event === 'add' || event === 'change') && this._readyEmitted) {
+  if (awf && (event === 'add' || event === 'change')) {
     var awfEmit = function(err, stats) {
       if (err) {
         event = args[0] = 'error';


### PR DESCRIPTION
I did this change because files were being taken even with the awf options set until the ready event was not triggered. I'm watching near 10k+ in some servers, so it takes a while to complete, and some of them might be in the middle of a transfer when I start the process. 

Is there a reason why the lack of the ready event prevents awf being taken into account? Right now I cannot think of any, but of course there are many cases different than mine.