### PR TITLE
Consolidate common folders to avoid hitting the FSEvent limit

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -38,7 +38,7 @@ function createFSEventsInstance(path, callback) {
 function setFSEventsListener(path, realPath, listener, rawEmitter) {
   var watchPath = sysPath.extname(path) ? sysPath.dirname(path) : path;
   var watchContainer;
-  var parentPath = parentOf(watchPath);
+  var parentPath = sysPath.dirname(watchPath);
 
   // If we've accumulated a substantial number of paths that
   // could have been consolidated by watching one directory
@@ -119,11 +119,6 @@ function couldConsolidate(path) {
   }
 
   return false;
-}
-
-// Find the parent of a given path
-function parentOf (path) {
-  return path.split(sysPath.sep).slice(0, -1).join(sysPath.sep)
 }
 
 // returns boolean indicating whether fsevents can be used

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -34,6 +34,15 @@ function createFSEventsInstance(path, callback) {
 function setFSEventsListener(path, realPath, listener, rawEmitter) {
   var watchPath = sysPath.extname(path) ? sysPath.dirname(path) : path;
   var watchContainer;
+  var parentPath = parentOf(watchPath);
+
+  // If we've accumulated a substantial number of paths that
+  // could have been consolidated by watching one directory
+  // above the current one, create a watcher on the parent
+  // path instead, so that we do consolidate going forward.
+  if (couldConsolidate(parentPath)) {
+    watchPath = parentPath;
+  }
 
   var resolvedPath = sysPath.resolve(path);
   var hasSymlink = resolvedPath !== realPath;
@@ -89,9 +98,36 @@ function setFSEventsListener(path, realPath, listener, rawEmitter) {
   };
 }
 
+var consolidateThreshhold = 10;
+
+// Decide whether or not we should start a new higher-level
+// parent watcher
+function couldConsolidate(path) {
+  var candidates = {};
+  var keys = Object.keys(FSEventsWatchers)
+  var count = 0
+
+  for (var i = 0, len = keys.length; i < len; ++i) {
+    var watchPath = keys[i]
+    if (watchPath.indexOf(path) === 0) {
+      count++
+      if (count >= consolidateThreshhold) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+// Find the parent of a given path
+function parentOf (path) {
+  return path.split(sysPath.sep).slice(0, -1).join(sysPath.sep)
+}
+
 // returns boolean indicating whether fsevents can be used
 function canUse() {
-  return !!fsevents;
+  return fsevents && Object.keys(FSEventsWatchers).length < 128;
 }
 
 // determines subdirectory traversal levels from root to path

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -91,7 +91,7 @@ function setFSEventsListener(path, realPath, listener, rawEmitter) {
 
 // returns boolean indicating whether fsevents can be used
 function canUse() {
-  return fsevents && Object.keys(FSEventsWatchers).length < 128;
+  return !!fsevents;
 }
 
 // determines subdirectory traversal levels from root to path

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -12,6 +12,10 @@ try { fsevents = require('fsevents'); } catch (error) {}
 // (may be shared across chokidar FSWatcher instances)
 var FSEventsWatchers = Object.create(null);
 
+// Threshold of duplicate path prefixes at which to start
+// consolidating going forward
+var consolidateThreshhold = 10;
+
 // Private function: Instantiates the fsevents interface
 
 // * path       - string, path to be watched
@@ -98,26 +102,23 @@ function setFSEventsListener(path, realPath, listener, rawEmitter) {
   };
 }
 
-var consolidateThreshhold = 10;
-
 // Decide whether or not we should start a new higher-level
 // parent watcher
 function couldConsolidate(path) {
-  var candidates = {};
-  var keys = Object.keys(FSEventsWatchers)
-  var count = 0
+  var keys = Object.keys(FSEventsWatchers);
+  var count = 0;
 
   for (var i = 0, len = keys.length; i < len; ++i) {
-    var watchPath = keys[i]
+    var watchPath = keys[i];
     if (watchPath.indexOf(path) === 0) {
-      count++
+      count++;
       if (count >= consolidateThreshhold) {
-        return true
+        return true;
       }
     }
   }
 
-  return false
+  return false;
 }
 
 // Find the parent of a given path


### PR DESCRIPTION
@es128  Here's the PR for #482. Let me know if you want me to fix anything up or change it.

It does a great job on my project. Goes from 200+ instances to 19-35 (it's somewhat non-deterministic because the way the algorithm works, it depends on the order they accumulate in).