### PR TITLE
Fix add for renamed dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,9 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
     this.options.alwaysStat && val1 === undefined &&
     (event === 'add' || event === 'addDir' || event === 'change')
   ) {
-    fs.stat(path, function(error, stats) {
+    var fullPath = path;
+    if (this.options.cwd) fullPath = sysPath.join(this.options.cwd, path);
+    fs.stat(fullPath, function(error, stats) {
       // Suppress event when fs.stat fails, to avoid sending undefined 'stat'
       if (error || !stats) return;
 

--- a/index.js
+++ b/index.js
@@ -206,8 +206,7 @@ FSWatcher.prototype._emit = function(event, path, val1, val2, val3) {
     this.options.alwaysStat && val1 === undefined &&
     (event === 'add' || event === 'addDir' || event === 'change')
   ) {
-    var fullPath = path;
-    if (this.options.cwd) fullPath = sysPath.join(this.options.cwd, path);
+    var fullPath = this.options.cwd ? sysPath.join(this.options.cwd, path) : path;
     fs.stat(fullPath, function(error, stats) {
       // Suppress event when fs.stat fails, to avoid sending undefined 'stat'
       if (error || !stats) return;

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -363,7 +363,9 @@ function(path, transform, forceAdd, priorDepth) {
         } else {
           emitAdd(joinedPath, entry.stat);
         }
-      }.bind(this)).on('end', this._emitReady);
+      }.bind(this)).on('error', function() {
+        // Ignore readdirp errors
+      }).on('end', this._emitReady);
     } else {
       emitAdd(wh.watchPath, stats);
       this._emitReady();

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -202,7 +202,7 @@ function(watchPath, realPath, transform, globFilter) {
         }
         var eventName = info.type === 'directory' ? event + 'Dir' : event;
         this._emit(eventName, path);
-        if (eventName === 'addDir') this._addToFsEvents(path);
+        if (eventName === 'addDir') this._addToFsEvents(path, false, true);
       }
     }.bind(this);
 
@@ -372,7 +372,7 @@ function(path, transform, forceAdd, priorDepth) {
     }
   }.bind(this));
 
-  if (this.options.persistent) {
+  if (this.options.persistent && forceAdd !== true) {
     var initWatch = function(error, realPath) {
       var closer = this._watchWithFsEvents(
         wh.watchPath,

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -202,6 +202,7 @@ function(watchPath, realPath, transform, globFilter) {
         }
         var eventName = info.type === 'directory' ? event + 'Dir' : event;
         this._emit(eventName, path);
+        if (eventName === 'addDir') this._addToFsEvents(path);
       }
     }.bind(this);
 

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -139,7 +139,7 @@ function FsEventsHandler() {}
 
 // Private method: Handle symlinks encountered during directory scan
 
-// * wathPath   - string, file/dir path to be watched with fsevents
+// * watchPath  - string, file/dir path to be watched with fsevents
 // * realPath   - string, real path (in case of symlinks)
 // * transform  - function, path transformer
 // * globFilter - function, path filter in case a glob pattern was provided

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "coveralls": "^2.11.2",
+    "graceful-fs": "4.1.4",
     "istanbul": "^0.3.20",
     "mocha": "^2.0.0",
     "rimraf": "^2.4.3",

--- a/test.js
+++ b/test.js
@@ -461,7 +461,7 @@ function runTests(baseopts) {
             .on('ready', function() {
               setTimeout(function() {
                 fs.rename(testDir, renamedDir, simpleCb);
-              });
+              }, 500);
               waitFor([spy], function() {
                 spy.should.have.been.calledOnce;
                 spy.should.have.been.calledWith(expectedPath);
@@ -1003,7 +1003,7 @@ function runTests(baseopts) {
               w(function() {
                 spy.should.not.have.been.called;
                 done();
-              }, 500)();
+              }, 1000)();
           });
         });
         it('should notice when a file appears in an empty directory', function(done) {
@@ -1311,7 +1311,7 @@ function runTests(baseopts) {
             .on('ready', function() {
               setTimeout(function() {
                 fs.rename(testDir, renamedDir, simpleCb);
-              }, 1000);
+              }, 500);
               waitFor([spy], function() {
                 spy.should.have.been.calledOnce;
                 spy.should.have.been.calledWith('subdir-renamed');

--- a/test.js
+++ b/test.js
@@ -1272,6 +1272,27 @@ function runTests(baseopts) {
             });
           });
       });
+      it('should emit `addDir` with alwaysStat for renamed directory', function(done) {
+        options.cwd = fixturesPath;
+        options.alwaysStat = true;
+        options.ignoreInitial = true;
+        var spy = sinon.spy();
+        var testDir = getFixturePath('subdir');
+        var renamedDir = getFixturePath('subdir-renamed');
+        fs.mkdir(testDir, 0x1ed, function() {
+          watcher = chokidar.watch('.', options)
+            .on('addDir', spy)
+            .on('ready', function() {
+                fs.rename(testDir, renamedDir, simpleCb)
+                waitFor([spy], function() {
+                  spy.should.have.been.calledOnce;
+                  spy.should.have.been.calledWith('subdir-renamed');
+                  expect(spy.args[0][1]).to.be.ok; // stats
+                  done();
+                });
+              });
+        });
+      });
       it('should allow separate watchers to have different cwds', function(done) {
         options.cwd = fixturesPath;
         var spy1 = sinon.spy();

--- a/test.js
+++ b/test.js
@@ -446,6 +446,30 @@ function runTests(baseopts) {
         }));
     });
   });
+  describe('renamed directory', function() {
+    it('should emit `add` for a file in a renamed directory', function(done) {
+      options.ignoreInitial = true;
+      var spy = sinon.spy();
+      var testDir = getFixturePath('subdir');
+      var testPath = getFixturePath('subdir/add.txt');
+      var renamedDir = getFixturePath('subdir-renamed');
+      var expectedPath = sysPath.join(renamedDir, 'add.txt')
+      fs.mkdir(testDir, 0x1ed, function() {
+        fs.writeFile(testPath, Date.now(), function() {
+          watcher = chokidar.watch(fixturesPath, options)
+            .on('add', spy)
+            .on('ready', function() {
+              fs.rename(testDir, renamedDir, simpleCb);
+              waitFor([spy], function() {
+                spy.should.have.been.calledOnce;
+                spy.should.have.been.calledWith(expectedPath);
+                done();
+              });
+            });
+        });
+      });
+    });
+  });
   describe('watch non-existent paths', function() {
     it('should watch non-existent file and detect add', function(done) {
       var spy = sinon.spy();

--- a/test.js
+++ b/test.js
@@ -459,9 +459,9 @@ function runTests(baseopts) {
           watcher = chokidar.watch(fixturesPath, options)
             .on('add', spy)
             .on('ready', function() {
-              setTimeout(function() {
+              w(function() {
                 fs.rename(testDir, renamedDir, simpleCb);
-              }, 500);
+              }, 1000)();
               waitFor([spy], function() {
                 spy.should.have.been.calledOnce;
                 spy.should.have.been.calledWith(expectedPath);
@@ -1307,11 +1307,11 @@ function runTests(baseopts) {
         var renamedDir = getFixturePath('subdir-renamed');
         fs.mkdir(testDir, 0x1ed, function() {
           watcher = chokidar.watch('.', options)
-            .on('addDir', spy)
             .on('ready', function() {
-              setTimeout(function() {
+              w(function() {
+                watcher.on('addDir', spy)
                 fs.rename(testDir, renamedDir, simpleCb);
-              }, 500);
+              }, 1000)();
               waitFor([spy], function() {
                 spy.should.have.been.calledOnce;
                 spy.should.have.been.calledWith('subdir-renamed');

--- a/test.js
+++ b/test.js
@@ -1283,7 +1283,9 @@ function runTests(baseopts) {
           watcher = chokidar.watch('.', options)
             .on('addDir', spy)
             .on('ready', function() {
-                fs.rename(testDir, renamedDir, simpleCb)
+                w(function() {
+                  fs.rename(testDir, renamedDir, simpleCb);
+                }, 1000);
                 waitFor([spy], function() {
                   spy.should.have.been.calledOnce;
                   spy.should.have.been.calledWith('subdir-renamed');

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ var expect = chai.expect;
 var should = chai.should();
 var sinon = require('sinon');
 var rimraf = require('rimraf');
-var fs = require('fs');
+var fs = require('graceful-fs');
 var sysPath = require('path');
 chai.use(require('sinon-chai'));
 var os = process.platform;

--- a/test.js
+++ b/test.js
@@ -459,7 +459,9 @@ function runTests(baseopts) {
           watcher = chokidar.watch(fixturesPath, options)
             .on('add', spy)
             .on('ready', function() {
-              fs.rename(testDir, renamedDir, simpleCb);
+              setTimeout(function() {
+                fs.rename(testDir, renamedDir, simpleCb);
+              });
               waitFor([spy], function() {
                 spy.should.have.been.calledOnce;
                 spy.should.have.been.calledWith(expectedPath);
@@ -1307,16 +1309,16 @@ function runTests(baseopts) {
           watcher = chokidar.watch('.', options)
             .on('addDir', spy)
             .on('ready', function() {
-                w(function() {
-                  fs.rename(testDir, renamedDir, simpleCb);
-                }, 1000);
-                waitFor([spy], function() {
-                  spy.should.have.been.calledOnce;
-                  spy.should.have.been.calledWith('subdir-renamed');
-                  expect(spy.args[0][1]).to.be.ok; // stats
-                  done();
-                });
+              setTimeout(function() {
+                fs.rename(testDir, renamedDir, simpleCb);
+              }, 1000);
+              waitFor([spy], function() {
+                spy.should.have.been.calledOnce;
+                spy.should.have.been.calledWith('subdir-renamed');
+                expect(spy.args[0][1]).to.be.ok; // stats
+                done();
               });
+            });
         });
       });
       it('should allow separate watchers to have different cwds', function(done) {


### PR DESCRIPTION
This is the PR #475 + a fix for files in a renamed directory. Chokidar was sending `unlink` events for the previous location of the files, but no `add` for the new location.

The tests are not ideal (sometimes green and sometimes red on my macbook). But I think it's just that fsevents can be slow, not a real bug.