### PR TITLE
Avoid calling _emitReady twice in case of a stat error

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -327,7 +327,6 @@ function(path, transform, forceAdd, priorDepth) {
   // evaluate what is at the path we're being asked to watch
   fs[wh.statMethod](wh.watchPath, function(error, stats) {
     if (this._handleError(error) || this._isIgnored(wh.watchPath, stats)) {
-      this._emitReady();
       return this._emitReady();
     }
 


### PR DESCRIPTION
The `stat` just accounts for one ready count, namely the one for initial search.  In case of persistent watching, there will still be a watcher set up for the missing file, after which `_emitReady` will be called.

This fixes #338.