### PR TITLE
Add ready-aware `.close` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ name and path for every event other than `ready`, `raw`, and `error`.
 * `.unwatch(path / paths)`: Stop watching files, directories, or glob patterns.
 Takes an array of strings or just one string.
 * `.close()`: Removes all listeners from watched files.
+* `.stop(?cb)`: Asynchronous `.close()`. (https://github.com/paulmillr/chokidar/issues/434)
 * `.getWatched()`: Returns an object representing all the paths on the file
 system being watched by this `FSWatcher` instance. The object's keys are all the
 directories (using absolute paths unless the `cwd` option was used), and the

--- a/index.js
+++ b/index.js
@@ -658,11 +658,21 @@ FSWatcher.prototype.unwatch = function(paths) {
   return this;
 };
 
-// Public method: Close watchers and remove all listeners from watched paths.
-
+// Private method: Close watchers and remove all listeners from watched paths.
+//
+// * cb     - function to be called after watcher has been successfully closed.
+//
 // Returns instance of FSWatcher for chaining.
-FSWatcher.prototype.close = function() {
-  if (this.closed) return this;
+FSWatcher.prototype.close = function(cb) {
+  if (this.closed) {
+      if (cb) cb();
+      return this;
+  }
+
+  if (!this._readyEmitted) {
+      this.on('ready', this.close.bind(this, cb));
+      return this;
+  }
 
   this.closed = true;
   Object.keys(this._closers).forEach(function(watchPath) {
@@ -672,6 +682,7 @@ FSWatcher.prototype.close = function() {
   this._watched = Object.create(null);
 
   this.removeAllListeners();
+  if (cb) cb();
   return this;
 };
 

--- a/test.js
+++ b/test.js
@@ -77,21 +77,37 @@ beforeEach(function() {
   fixturesPath = getFixturePath('');
 });
 
-function closeWatchers() {
+function closeWatchers(done) {
   var u;
-  while (u = usedWatchers.pop()) u.close();
+  if (!usedWatchers.length) done();
+  while (u = usedWatchers.pop()) {
+    u.close(closeWatchers.bind(null, done));
+  }
 }
-function disposeWatcher(watcher) {
-  if (!watcher || !watcher.close) return;
-  osXFsWatch ? usedWatchers.push(watcher) : watcher.close();
+function disposeWatcher(watcher, done) {
+  if (!watcher || !watcher.close) {
+      done();
+      return;
+  }
+  osXFsWatch ? usedWatchers.push(watcher) : watcher.close(done);
+  return
 }
-afterEach(function() {
-  disposeWatcher(watcher);
-  disposeWatcher(watcher2);
+afterEach(function(done) {
+  function _done() {
+    if ((!watcher || watcher.closed) && (!watcher2 || watcher2.closed)) {
+      done();
+    }
+  }
+  disposeWatcher(watcher, _done);
+  disposeWatcher(watcher2, _done);
+  if (osXFsWatch) {
+      done();
+  }
 });
 
 describe('chokidar', function() {
-  this.timeout(6000);
+  this.timeout(10000);
+  this.slow(400);
   it('should expose public API methods', function() {
     chokidar.FSWatcher.should.be.a('function');
     chokidar.watch.should.be.a('function');
@@ -1746,17 +1762,18 @@ function runTests(baseopts) {
         });
     });
   });
-  describe('close', function() {
+  describe('close', function(done) {
     it('should ignore further events on close', function(done) {
       var spy = sinon.spy();
       watcher = chokidar.watch(fixturesPath, options).once('add', function() {
         watcher.once('add', function() {
-          watcher.on('add', spy).close();
-          fs.writeFile(getFixturePath('add.txt'), Date.now(), simpleCb);
-          w(function() {
-            spy.should.not.have.been.called;
-            done();
-          }, 900)();
+          watcher.on('add', spy).close(function() {
+              fs.writeFile(getFixturePath('add.txt'), Date.now(), simpleCb);
+              w(function() {
+                spy.should.not.have.been.called;
+                done();
+              }, 900)();
+          });
         });
       }).on('ready', function() {
         fs.writeFile(getFixturePath('add.txt'), 'hello', function() {

--- a/test.js
+++ b/test.js
@@ -77,37 +77,21 @@ beforeEach(function() {
   fixturesPath = getFixturePath('');
 });
 
-function closeWatchers(done) {
+function closeWatchers() {
   var u;
-  if (!usedWatchers.length) done();
-  while (u = usedWatchers.pop()) {
-    u.close(closeWatchers.bind(null, done));
-  }
+  while (u = usedWatchers.pop()) u.close();
 }
-function disposeWatcher(watcher, done) {
-  if (!watcher || !watcher.close) {
-      done();
-      return;
-  }
-  osXFsWatch ? usedWatchers.push(watcher) : watcher.close(done);
-  return
+function disposeWatcher(watcher) {
+  if (!watcher || !watcher.close) return;
+  osXFsWatch ? usedWatchers.push(watcher) : watcher.close();
 }
-afterEach(function(done) {
-  function _done() {
-    if ((!watcher || watcher.closed) && (!watcher2 || watcher2.closed)) {
-      done();
-    }
-  }
-  disposeWatcher(watcher, _done);
-  disposeWatcher(watcher2, _done);
-  if (osXFsWatch) {
-      done();
-  }
+afterEach(function() {
+  disposeWatcher(watcher);
+  disposeWatcher(watcher2);
 });
 
 describe('chokidar', function() {
-  this.timeout(10000);
-  this.slow(400);
+  this.timeout(6000);
   it('should expose public API methods', function() {
     chokidar.FSWatcher.should.be.a('function');
     chokidar.watch.should.be.a('function');
@@ -1762,18 +1746,17 @@ function runTests(baseopts) {
         });
     });
   });
-  describe('close', function(done) {
+  describe('close', function() {
     it('should ignore further events on close', function(done) {
       var spy = sinon.spy();
       watcher = chokidar.watch(fixturesPath, options).once('add', function() {
         watcher.once('add', function() {
-          watcher.on('add', spy).close(function() {
-              fs.writeFile(getFixturePath('add.txt'), Date.now(), simpleCb);
-              w(function() {
-                spy.should.not.have.been.called;
-                done();
-              }, 900)();
-          });
+          watcher.on('add', spy).close();
+          fs.writeFile(getFixturePath('add.txt'), Date.now(), simpleCb);
+          w(function() {
+            spy.should.not.have.been.called;
+            done();
+          }, 900)();
         });
       }).on('ready', function() {
         fs.writeFile(getFixturePath('add.txt'), 'hello', function() {


### PR DESCRIPTION
https://github.com/paulmillr/chokidar/issues/434

I'm not sure how you wanted to approach this but I initially made `.close` itself ready-aware however  it added a bunch of complexity to the test suite and slowed it down considerably which made me think it would be a pretty significant breaking change. You can see that attempt here -- https://github.com/60frames/chokidar/commit/192c6f6edc08100c5014d1de1a01f540d0236499

I then decided to revert back and take the easier approach of creating a separate `.stop` method, seen in this PR.
