### PR TITLE
Improve ignore paths globifying

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,19 @@ var isString = function(thing) {
   return typeof thing === 'string';
 };
 
+var globify = function(path) {
+  var ret;
+  if (path.slice(-1) === sysPath.sep) {
+    ret = path + '**';
+  } else {
+    ret = path + sysPath.sep + '**';
+  }
+  if (!sysPath.isAbsolute(path)) {
+    ret = '**' + sysPath.sep + ret;
+  }
+  return ret;
+};
+
 // Public: Main class.
 // Watches files & directories for changes.
 //
@@ -356,9 +369,7 @@ FSWatcher.prototype._isIgnored = function(path, stats) {
     var paths = arrify(ignored)
       .filter(function(path) {
         return typeof path === 'string' && !isGlob(path);
-      }).map(function(path) {
-        return path + '/**';
-      });
+      }).map(globify);
     this._userIgnored = anymatch(
       this._globIgnored.concat(ignored).concat(paths)
     );
@@ -594,7 +605,7 @@ FSWatcher.prototype.add = function(paths, _origAdd, _internal) {
     } else {
       // if a path is being added that was previously ignored, stop ignoring it
       delete this._ignoredPaths[path];
-      delete this._ignoredPaths[path + '/**'];
+      delete this._ignoredPaths[globify(path)];
 
       // reset the cached userIgnored anymatch fn
       // to make ignoredPaths changes effective
@@ -647,7 +658,7 @@ FSWatcher.prototype.unwatch = function(paths) {
 
     this._ignoredPaths[path] = true;
     if (path in this._watched) {
-      this._ignoredPaths[path + '/**'] = true;
+      this._ignoredPaths[globify(path)] = true;
     }
 
     // reset the cached userIgnored anymatch fn

--- a/test.js
+++ b/test.js
@@ -1100,6 +1100,40 @@ function runTests(baseopts) {
             }, 300));
           }));
       });
+      it('should ignore paths provided only a directory name without ending slash', function(done) {
+        var spy = sinon.spy();
+        var testDir = getFixturePath('subdir');
+        var testFile = sysPath.join(testDir, 'add.txt');
+        options.ignored = 'subdir';
+        fs.mkdirSync(testDir, 0x1ed);
+        fs.writeFileSync(testFile, 'b');
+        watcher = chokidar.watch(fixturesPath, options)
+          .on('all', spy)
+          .on('ready', w(function() {
+            fs.writeFile(testFile, Date.now(), w(function() {
+              spy.should.not.have.been.calledWith('add', testFile);
+              spy.should.not.have.been.calledWith('change', testFile);
+              done();
+            }, 300));
+          }));
+      });
+      it('should ignore paths provided only a directory name with ending slash', function(done) {
+        var spy = sinon.spy();
+        var testDir = getFixturePath('subdir');
+        var testFile = sysPath.join(testDir, 'add.txt');
+        options.ignored = 'subdir/';
+        fs.mkdirSync(testDir, 0x1ed);
+        fs.writeFileSync(testFile, 'b');
+        watcher = chokidar.watch(fixturesPath, options)
+          .on('all', spy)
+          .on('ready', w(function() {
+            fs.writeFile(testFile, Date.now(), w(function() {
+              spy.should.not.have.been.calledWith('add', testFile);
+              spy.should.not.have.been.calledWith('change', testFile);
+              done();
+            }, 300));
+          }));
+      });
       it('should allow regex/fn ignores', function(done) {
         options.cwd = fixturesPath;
         options.ignored = /add/;


### PR DESCRIPTION
Ensures that if only a directory's basename is provided (without the preceeding path, just `dirname`), it prefixes `**/`

Currently when only a directory name is provided, it adds a postfix `/**` which is great for matching the entire tree ***if*** the tree is a *child* of the dir.  So `path` (converted to `path/**`) can filter paths like `path/to/file.js`, **but** if `path` is actually only a directory's basename it fails to match `/some/path/to/file.js`. This can be solved by prefixing `**/path`

Really helpful when only "node_modules" is provided as ignore path (like in `.gitignore` file). 

This could probably have solved #447, which if I followed correctly [the solution][1] ultimately was to add paths in similar patterns

        "**/.git/objects/**"
        "**/node_modules/**"

Also adjust the postfix to add just `**` instead of `/**` based on if last char is already a `/`

[1]: https://github.com/Microsoft/vscode/issues/3222#issuecomment-195001923