### PR TITLE
Fix for possible infinite recursion.

### DIFF
--- a/index.js
+++ b/index.js
@@ -465,7 +465,7 @@ FSWatcher.prototype._getWatchedDir = function(directory) {
   if (!(dir in this._watched)) this._watched[dir] = {
     _items: Object.create(null),
     add: function(item) {
-      if (item !== '.') this._items[item] = true;
+      if (item !== '.' && item !== '..') this._items[item] = true;
     },
     remove: function(item) {
       delete this._items[item];


### PR DESCRIPTION
On a Windows 10 Pro machine with Node.js 7.5 I often get the following error:
```
22 02 2017 11:58:47.739:ERROR [karma]: RangeError: Maximum call stack size exceeded
    at Object.normalize (path.js:405:40)
    at Object.join (path.js:529:18)
    at FSWatcher._remove (C:\Projects\someproject\node_modules\chokidar\index.js:486:22)
    at FSWatcher.<anonymous> (C:\Projects\someproject\node_modules\chokidar\index.js:506:10)
    at Array.forEach (native)
    at FSWatcher._remove (C:\Projects\someproject\node_modules\chokidar\index.js:505:27)
    at FSWatcher.<anonymous> (C:\Projects\someproject\node_modules\chokidar\index.js:506:10)
    at Array.forEach (native)
    at FSWatcher._remove (C:\Projects\someproject\node_modules\chokidar\index.js:505:27)
    at FSWatcher.<anonymous> (C:\Projects\someproject\node_modules\chokidar\index.js:506:10)
    at Array.forEach (native)
    at FSWatcher._remove (C:\Projects\someproject\node_modules\chokidar\index.js:505:27)
    at FSWatcher.<anonymous> (C:\Projects\someproject\node_modules\chokidar\index.js:506:10)
    at Array.forEach (native)
    at FSWatcher._remove (C:\Projects\someproject\node_modules\chokidar\index.js:505:27)
    at FSWatcher.<anonymous> (C:\Projects\someproject\node_modules\chokidar\index.js:506:10)
```

I found that in `FSWatcher.prototype._remove` `nestedDirectoryChildren` may contain `..` sometimes, which will lead to infinite recursion within `FSWatcher.prototype._remove`. The path starts out as `../../../`, nested item is `..`. And it'll start calling remove with directory: `../../../`, item: `..`, next call will be `../../../../`, item: `..`, next `../../../../../`, item: `..` and so on until recursion limit is hit.