### PR TITLE
🐜  Detect non-null 'options.ignored'

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -221,7 +221,7 @@ function(watchPath, realPath, transform, globFilter) {
       69888, 70400, 71424, 72704, 73472, 131328, 131840, 262912
     ];
     if (wrongEventFlags.indexOf(flags) !== -1 || info.event === 'unknown') {
-      if (typeof this.options.ignored === 'function') {
+      if (this.options.ignored != null) {
         fs.stat(path, function(error, stats) {
           if (checkIgnored(stats)) return;
           stats ? addOrChange() : handleEvent('unlink');


### PR DESCRIPTION
The value of `options.ignored` can be a string, function, regexp, or mixed array.

Strangely, no tests failed before or after this change.
Probably need to add an edge case.