### PR TITLE
🐜  Make 'ready' event work as expected

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -327,7 +327,6 @@ function(path, transform, forceAdd, priorDepth) {
   // evaluate what is at the path we're being asked to watch
   fs[wh.statMethod](wh.watchPath, function(error, stats) {
     if (this._handleError(error) || this._isIgnored(wh.watchPath, stats)) {
-      this._emitReady();
       return this._emitReady();
     }
 
@@ -336,7 +335,9 @@ function(path, transform, forceAdd, priorDepth) {
       if (!wh.globFilter) emitAdd(processPath(path), stats);
 
       // don't recurse further if it would exceed depth setting
-      if (priorDepth && priorDepth > this.options.depth) return;
+      if (priorDepth && priorDepth > this.options.depth) {
+        return this._emitReady();
+      }
 
       // scan the contents of the dir
       readdirp({


### PR DESCRIPTION
- Add a missing `_emitReady` call when `options.depth` is exceeded.
- Only call `_emitReady` once after fetching the `stats` of a watched path.

---

### Failing tests

```
  1) chokidar fsevents (native extension) watch options ignored should not choke on an ignored watch path:
     Error: Timeout of 6000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

Looks like the "ready" event is not emitted when zero files are watched.