### PR TITLE
🐜  Pass `directory` to the `_getWatchedDir` method

### DIFF
--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -349,7 +349,7 @@ function(dir, stats, initialAdd, depth, target, wh, callback) {
       if (!throttler) return;
     }
 
-    var previous = this._getWatchedDir(wh.path);
+    var previous = this._getWatchedDir(directory);
     var current = [];
 
     readdirp({


### PR DESCRIPTION
The value of `wh.path` might be a glob, so we cannot safely pass it to `_getWatchedDir`.
If we did that, a new entry in the `_watched` map would be created.
Additionally, the call to `fs.readDir` would be passed a glob (undefined behavior?).

This only applies when `options.useFsEvents` is false.

[8 failing tests](http://pastebin.com/raw/SsCPpX3X)

Let me know if I'm misunderstanding something. 😄 