### PR TITLE
ignoreGlobs option: treat glob-like paths as literal paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ chokidar.watch('file', {
   ignoreInitial: false,
   followSymlinks: true,
   cwd: '.',
+  disableGlobbing: false,
 
   usePolling: true,
   interval: 100,
@@ -168,6 +169,8 @@ symlinks themselves will be watched for changes instead of following
 the link references and bubbling events through the link's path.
 * `cwd` (no default). The base directory from which watch `paths` are to be
 derived. Paths emitted with events will be relative to this.
+* `disableGlobbing` (default: `false`). If set to `true` then the strings passed to `.watch()` and `.add()` are treated as
+literal path names, even if they look like globs.
 
 #### Performance
 

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function FSWatcher(_opts) {
   if (undef('ignorePermissionErrors')) opts.ignorePermissionErrors = false;
   if (undef('interval')) opts.interval = 100;
   if (undef('binaryInterval')) opts.binaryInterval = 300;
-  if (undef('ignoreGlobs')) opts.ignoreGlobs = false;
+  if (undef('disableGlobbing')) opts.disableGlobbing = false;
   this.enableBinaryInterval = opts.binaryInterval !== opts.interval;
 
   // Enable fsevents on OS X when polling isn't explicitly enabled.
@@ -378,7 +378,7 @@ FSWatcher.prototype._isIgnored = function(path, stats) {
 var replacerRe = /^\.[\/\\]/;
 FSWatcher.prototype._getWatchHelpers = function(path, depth) {
   path = path.replace(replacerRe, '');
-  var watchPath = depth || this.options.ignoreGlobs || !isGlob(path) ? path : globParent(path);
+  var watchPath = depth || this.options.disableGlobbing || !isGlob(path) ? path : globParent(path);
   var fullWatchPath = sysPath.resolve(watchPath);
   var hasGlob = watchPath !== path;
   var globFilter = hasGlob ? anymatch(path) : false;

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ function FSWatcher(_opts) {
   if (undef('ignorePermissionErrors')) opts.ignorePermissionErrors = false;
   if (undef('interval')) opts.interval = 100;
   if (undef('binaryInterval')) opts.binaryInterval = 300;
+  if (undef('ignoreGlobs')) opts.ignoreGlobs = false;
   this.enableBinaryInterval = opts.binaryInterval !== opts.interval;
 
   // Enable fsevents on OS X when polling isn't explicitly enabled.
@@ -377,7 +378,7 @@ FSWatcher.prototype._isIgnored = function(path, stats) {
 var replacerRe = /^\.[\/\\]/;
 FSWatcher.prototype._getWatchHelpers = function(path, depth) {
   path = path.replace(replacerRe, '');
-  var watchPath = depth || !isGlob(path) ? path : globParent(path);
+  var watchPath = depth || this.options.ignoreGlobs || !isGlob(path) ? path : globParent(path);
   var fullWatchPath = sysPath.resolve(watchPath);
   var hasGlob = watchPath !== path;
   var globFilter = hasGlob ? anymatch(path) : false;

--- a/test.js
+++ b/test.js
@@ -667,6 +667,24 @@ function runTests(baseopts) {
           });
       }));
     });
+    it('should treat glob-like paths as literal paths when globbing is disabled', function(done) {
+      options.ignoreGlobs = true;
+      var spy = sinon.spy();
+      var filePath = getFixturePath('nota[glob]/a.txt');
+      var watchPath = getFixturePath('nota[glob]');
+      fs.mkdirSync(watchPath, 0x1ed);
+      fs.writeFileSync(filePath, 'b');
+      watcher = chokidar.watch(watchPath, options)
+        .on('all', spy)
+        .on('ready', function() {
+          spy.should.have.been.calledWith('add', filePath);
+          w(fs.writeFile.bind(fs, filePath, Date.now(), simpleCb))();
+          waitFor([spy.withArgs('change', filePath)], function() {
+            spy.should.have.been.calledWith('change', filePath);
+            done();
+          });
+        });
+    });
     it('should not prematurely filter dirs against complex globstar patterns', function(done) {
       var spy = sinon.spy();
       var deepFile = getFixturePath('subdir/subsub/subsubsub/a.txt');

--- a/test.js
+++ b/test.js
@@ -667,7 +667,7 @@ function runTests(baseopts) {
           });
       }));
     });
-    it('should treat glob-like paths as literal paths when globbing is disabled', function(done) {
+    it('should treat glob-like directory names as literal directory names when globbing is disabled', function(done) {
       options.disableGlobbing = true;
       var spy = sinon.spy();
       var filePath = getFixturePath('nota[glob]/a.txt');
@@ -676,6 +676,32 @@ function runTests(baseopts) {
       var matchingFile = getFixturePath('notag/b.txt');
       var matchingFile2 = getFixturePath('notal');
       fs.mkdirSync(watchPath, 0x1ed);
+      fs.writeFileSync(filePath, 'b');
+      fs.mkdirSync(matchingDir, 0x1ed);
+      fs.writeFileSync(matchingFile, 'c');
+      fs.writeFileSync(matchingFile2, 'd');
+      watcher = chokidar.watch(watchPath, options)
+        .on('all', spy)
+        .on('ready', function() {
+          spy.should.have.been.calledWith('add', filePath);
+          spy.should.not.have.been.calledWith('addDir', matchingDir);
+          spy.should.not.have.been.calledWith('add', matchingFile);
+          spy.should.not.have.been.calledWith('add', matchingFile2);
+          w(fs.writeFile.bind(fs, filePath, Date.now(), simpleCb))();
+          waitFor([spy.withArgs('change', filePath)], function() {
+            spy.should.have.been.calledWith('change', filePath);
+            done();
+          });
+        });
+    });
+    it('should treat glob-like filenames as literal filenames when globbing is disabled', function(done) {
+      options.disableGlobbing = true;
+      var spy = sinon.spy();
+      var filePath = getFixturePath('nota[glob]');
+      var watchPath = getFixturePath('nota[glob]');
+      var matchingDir = getFixturePath('notag');
+      var matchingFile = getFixturePath('notag/a.txt');
+      var matchingFile2 = getFixturePath('notal');
       fs.writeFileSync(filePath, 'b');
       fs.mkdirSync(matchingDir, 0x1ed);
       fs.writeFileSync(matchingFile, 'c');

--- a/test.js
+++ b/test.js
@@ -672,12 +672,21 @@ function runTests(baseopts) {
       var spy = sinon.spy();
       var filePath = getFixturePath('nota[glob]/a.txt');
       var watchPath = getFixturePath('nota[glob]');
+      var matchingDir = getFixturePath('notag');
+      var matchingFile = getFixturePath('notag/b.txt');
+      var matchingFile2 = getFixturePath('notal');
       fs.mkdirSync(watchPath, 0x1ed);
       fs.writeFileSync(filePath, 'b');
+      fs.mkdirSync(matchingDir, 0x1ed);
+      fs.writeFileSync(matchingFile, 'c');
+      fs.writeFileSync(matchingFile2, 'd');
       watcher = chokidar.watch(watchPath, options)
         .on('all', spy)
         .on('ready', function() {
           spy.should.have.been.calledWith('add', filePath);
+          spy.should.not.have.been.calledWith('addDir', matchingDir);
+          spy.should.not.have.been.calledWith('add', matchingFile);
+          spy.should.not.have.been.calledWith('add', matchingFile2);
           w(fs.writeFile.bind(fs, filePath, Date.now(), simpleCb))();
           waitFor([spy.withArgs('change', filePath)], function() {
             spy.should.have.been.calledWith('change', filePath);

--- a/test.js
+++ b/test.js
@@ -668,7 +668,7 @@ function runTests(baseopts) {
       }));
     });
     it('should treat glob-like paths as literal paths when globbing is disabled', function(done) {
-      options.ignoreGlobs = true;
+      options.disableGlobbing = true;
       var spy = sinon.spy();
       var filePath = getFixturePath('nota[glob]/a.txt');
       var watchPath = getFixturePath('nota[glob]');


### PR DESCRIPTION
As discussed with @es128 at https://github.com/paulmillr/chokidar/issues/300.

Naming options is always tricky, so shout if you have a better suggestion than `ignoreGlobs`.

If you're happy with the code, I'll update the docs.