### PR TITLE
add requireFseventsCallback option

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function FSWatcher(_opts) {
   if (undef('useFsEvents')) opts.useFsEvents = !opts.usePolling;
 
   if (opts.useFsEvents) {
-    FsEventsHandler.initFsEvents(opts.fseventsPath, opts.requireFseventsCallback);
+    FsEventsHandler.initFsEvents(opts.fseventsPath, opts.useFsEvents, opts.requireFseventsCallback);
   }
 
   // If we can't use fsevents, ensure the options reflect it's disabled.

--- a/index.js
+++ b/index.js
@@ -82,10 +82,16 @@ function FSWatcher(_opts) {
   // Enable fsevents on OS X when polling isn't explicitly enabled.
   if (undef('useFsEvents')) opts.useFsEvents = !opts.usePolling;
 
-  if (opts.useFsEvents) FsEventsHandler.init(opts.requireFseventsCallback);
+  if (opts.useFsEvents) {
+    FsEventsHandler.initFsEvents(opts.fseventsPath, opts.requireFseventsCallback);
+  }
 
   // If we can't use fsevents, ensure the options reflect it's disabled.
-  if (!FsEventsHandler.canUse()) opts.useFsEvents = false;
+  if (!FsEventsHandler.canUse()) {
+    opts.useFsEvents = false;
+  } else {
+    importHandler(FsEventsHandler);
+  }
 
   // Use polling on Mac if not using fsevents.
   // Other platforms use non-polling fs.watch.
@@ -702,7 +708,6 @@ function importHandler(handler) {
   });
 }
 importHandler(NodeFsHandler);
-if (FsEventsHandler.canUse()) importHandler(FsEventsHandler);
 
 // Export FSWatcher class
 exports.FSWatcher = FSWatcher;

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function FSWatcher(_opts) {
   // Enable fsevents on OS X when polling isn't explicitly enabled.
   if (undef('useFsEvents')) opts.useFsEvents = !opts.usePolling;
 
-  FsEventsHandler.init(opts.requireFseventsCallback);
+  if (opts.useFsEvents) FsEventsHandler.init(opts.requireFseventsCallback);
 
   // If we can't use fsevents, ensure the options reflect it's disabled.
   if (!FsEventsHandler.canUse()) opts.useFsEvents = false;

--- a/index.js
+++ b/index.js
@@ -82,6 +82,8 @@ function FSWatcher(_opts) {
   // Enable fsevents on OS X when polling isn't explicitly enabled.
   if (undef('useFsEvents')) opts.useFsEvents = !opts.usePolling;
 
+  FsEventsHandler.init(opts.requireFseventsCallback);
+
   // If we can't use fsevents, ensure the options reflect it's disabled.
   if (!FsEventsHandler.canUse()) opts.useFsEvents = false;
 

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -3,8 +3,7 @@
 var fs = require('fs');
 var sysPath = require('path');
 var readdirp = require('readdirp');
-var fsevents;
-try { fsevents = require('fsevents'); } catch (error) {}
+var fsevents = {};
 
 // fsevents instance helper functions
 
@@ -393,5 +392,14 @@ function(path, transform, forceAdd, priorDepth) {
   }
 };
 
+function init(callback) {
+  try {
+    fsevents = require('fsevents');
+  } catch (error) {
+    callback && callback(error);
+  }
+}
+
 module.exports = FsEventsHandler;
 module.exports.canUse = canUse;
+module.exports.init = init;

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -396,13 +396,27 @@ function(path, transform, forceAdd, priorDepth) {
   }
 };
 
+function parseEnvVar(envVar) {
+  if (envVar !== undefined) {
+    var envLower = envVar.toLowerCase();
+    if (envLower === 'false' || envLower === '0') {
+      return false;
+    } else if (envLower === 'true' || envLower === '1') {
+      return true;
+    } else {
+      return !!envLower;
+    }
+  }
+}
+
 function initFsEvents(fseventsPath, useFsEvents, callback) {
   try {
     fseventsPath = fseventsPath || require.resolve('fsevents');
     fsevents = require(fseventsPath);
     callback && callback(null, fseventsPath);
   } catch (error) {
-    if (useFsEvents && process.env.CHOKIDAR_PRINT_FSEVENTS_REQUIRE_ERROR) {
+    var shouldPrintError = parseEnvVar(process.env.CHOKIDAR_PRINT_FSEVENTS_REQUIRE_ERROR);
+    if (useFsEvents && shouldPrintError) {
       var message = 'fsevents failed to be required by chokidar (' + __dirname + ')';
       console.log(message);
       console.log(error);

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -396,12 +396,17 @@ function(path, transform, forceAdd, priorDepth) {
   }
 };
 
-function initFsEvents(fseventsPath, callback) {
+function initFsEvents(fseventsPath, useFsEvents, callback) {
   try {
     fseventsPath = fseventsPath || require.resolve('fsevents');
     fsevents = require(fseventsPath);
     callback && callback(null, fseventsPath);
   } catch (error) {
+    if (useFsEvents && process.env.CHOKIDAR_PRINT_FSEVENTS_REQUIRE_ERROR) {
+      var message = 'fsevents failed to be required by chokidar (' + __dirname + ')';
+      console.log(message);
+      console.log(error);
+    }
     callback && callback(error);
   }
 }

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -120,9 +120,13 @@ function couldConsolidate(path) {
   return false;
 }
 
+function isEmptyObject(obj) {
+  return Object.keys(obj).length === 0 && obj.constructor === Object
+}
+
 // returns boolean indicating whether fsevents can be used
 function canUse() {
-  return fsevents && Object.keys(FSEventsWatchers).length < 128;
+  return !isEmptyObject(fsevents) && Object.keys(FSEventsWatchers).length < 128;
 }
 
 // determines subdirectory traversal levels from root to path
@@ -392,9 +396,11 @@ function(path, transform, forceAdd, priorDepth) {
   }
 };
 
-function init(callback) {
+function initFsEvents(fseventsPath, callback) {
   try {
-    fsevents = require('fsevents');
+    fseventsPath = fseventsPath || require.resolve('fsevents');
+    fsevents = require(fseventsPath);
+    callback && callback(null, fseventsPath);
   } catch (error) {
     callback && callback(error);
   }
@@ -402,4 +408,4 @@ function init(callback) {
 
 module.exports = FsEventsHandler;
 module.exports.canUse = canUse;
-module.exports.init = init;
+module.exports.initFsEvents = initFsEvents;


### PR DESCRIPTION
First draft.

I wanted to make the smallest change possible.

I initialized `var fsevents = {}` to get around the `'use strict'` restrictions of modifying uninitialised variables.

I chose a callback over an emitter because some of the options are updated depending on the result of `FsEventsHandler.canUse()` which require `fsevents` to have attempted to be required.

Not sure on the name of the option. Maybe its better as `requireFseventsErrorCallback`.

No tests at present but wanted to get feedback on approach first.

#599 

@es128 