### PR TITLE
print fsevents require error when env var set

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -3,33 +3,9 @@
 var fs = require('fs');
 var sysPath = require('path');
 var readdirp = require('readdirp');
-var fsevents = tryRequireFsEvents();
-
-function parseEnvVar(envVar) {
-  if (envVar !== undefined) {
-    var envLower = envVar.toLowerCase();
-    if (envLower === 'false' || envLower === '0') {
-      return false;
-    } else if (envLower === 'true' || envLower === '1') {
-      return true;
-    } else {
-      return !!envLower;
-    }
-  }
-}
-
-function tryRequireFsEvents() {
-  try {
-    return require('fsevents');
-  } catch (error) {
-    var shouldPrintError = parseEnvVar(process.env.CHOKIDAR_PRINT_FSEVENTS_REQUIRE_ERROR);
-    if (shouldPrintError) {
-      var message = 'fsevents failed to be required by chokidar (' + __dirname + ')';
-      console.log(message);
-      console.log(error);
-    }
-    return null;
-  }
+var fsevents;
+try { fsevents = require('fsevents'); } catch (error) {
+  if (process.env.CHOKIDAR_PRINT_FSEVENTS_REQUIRE_ERROR) console.error(error)
 }
 
 // fsevents instance helper functions

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -3,8 +3,34 @@
 var fs = require('fs');
 var sysPath = require('path');
 var readdirp = require('readdirp');
-var fsevents;
-try { fsevents = require('fsevents'); } catch (error) {}
+var fsevents = tryRequireFsEvents();
+
+function parseEnvVar(envVar) {
+  if (envVar !== undefined) {
+    var envLower = envVar.toLowerCase();
+    if (envLower === 'false' || envLower === '0') {
+      return false;
+    } else if (envLower === 'true' || envLower === '1') {
+      return true;
+    } else {
+      return !!envLower;
+    }
+  }
+}
+
+function tryRequireFsEvents() {
+  try {
+    return require('fsevents');
+  } catch (error) {
+    var shouldPrintError = parseEnvVar(process.env.CHOKIDAR_PRINT_FSEVENTS_REQUIRE_ERROR);
+    if (shouldPrintError) {
+      var message = 'fsevents failed to be required by chokidar (' + __dirname + ')';
+      console.log(message);
+      console.log(error);
+    }
+    return null;
+  }
+}
 
 // fsevents instance helper functions
 


### PR DESCRIPTION
I have used the same env var parsing code as in index.js.

Question: I have used two `console.log` statements. Should it be combined into one perhaps?

Will add tests after approval.

#599

@es128 