### PR TITLE
Updates fsevents dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sinon-chai": "^2.6.0"
   },
   "optionalDependencies": {
-    "fsevents": "^1.0.0"
+    "fsevents": "^1.1.2"
   },
   "dependencies": {
     "anymatch": "^1.3.0",


### PR DESCRIPTION
- fsevents is not publishing binaries for its older versions on new node versions.
- This updates fsevents so that package managers running on the latest node version will have binaries available