### PR TITLE
bump fsevents to 1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sinon-chai": "^2.6.0"
   },
   "optionalDependencies": {
-    "fsevents": "^1.0.0"
+    "fsevents": "^1.1.0"
   },
   "dependencies": {
     "anymatch": "^1.3.0",


### PR DESCRIPTION
`fsevents` version 1.1  successfully installed on windows but 1.0 not, with 1.1 `npm run test` passed.