### PR TITLE
“Drop” support for nodejs <v6. We still support it but unofficially.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Chokidar 2.0.0 (Dec 29, 2017)
 * Breaking: Upgrade globbing dependencies which require globs to be more strict and always use POSIX-style slashes because Windows-style slashes are used as escape sequences
+* Breaking: Drop official support of Node.js older than v6.0. Chokidar would still work, but don't expect too much stability.
 * Update tests to work with upgraded globbing dependencies
 * Add ability to log FSEvents require error by setting `CHOKIDAR_PRINT_FSEVENTS_REQUIRE_ERROR` env
 * Fix for handling braces in globs
-* Add node 8 & 9 to CI configs
 * Allow node 0.10 failures on Windows
 
 # Chokidar 1.7.0 (May 8, 2017)


### PR DESCRIPTION
cc @es128 @phated 

I think it's a reasonable move because basically no one supports it nowadays. Users who want to use it could fall back to v1.