### PR TITLE
Fix windows ignore when using anymatch@2 & cwd option

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var isGlob = require('is-glob');
 var isAbsolute = require('path-is-absolute');
 var inherits = require('inherits');
 var braces = require('braces');
-var normalizePath = require('normalize-path')
+var normalizePath = require('normalize-path');
+var upath = require('upath');
 
 var NodeFsHandler = require('./lib/nodefs-handler');
 var FsEventsHandler = require('./lib/fsevents-handler');
@@ -357,7 +358,7 @@ FSWatcher.prototype._isIgnored = function(path, stats) {
     if (cwd && ignored) {
       ignored = ignored.map(function (path) {
         if (typeof path !== 'string') return path;
-        return isAbsolute(path) ? path : sysPath.join(cwd, path);
+        return upath.normalize(isAbsolute(path) ? path : sysPath.join(cwd, path));
       });
     }
     var paths = arrify(ignored)

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "mocha": "^3.0.0",
     "rimraf": "^2.4.3",
     "sinon": "^1.10.3",
-    "sinon-chai": "^2.6.0",
-    "upath": "1.0.0"
+    "sinon-chai": "^2.6.0"
   },
   "optionalDependencies": {
     "fsevents": "^1.0.0"
@@ -54,6 +53,7 @@
     "is-glob": "^4.0.0",
     "normalize-path": "^2.1.1",
     "path-is-absolute": "^1.0.0",
-    "readdirp": "^2.0.0"
+    "readdirp": "^2.0.0",
+    "upath": "1.0.0"
   }
 }


### PR DESCRIPTION
Fixes #668

Chokidar@2 includes anymatch@2 which has a (potentially) breaking change
as described in the changelog: https://github.com/micromatch/anymatch#change-log

When the `cwd` is set Chokidar will join the ignore pattern to the cwd,
and if this isn't absolute, it causes `anymatch` to fail:

```js
// where cwd = c:\Users\remy\
anymatch('C:\\Users\\remy\\**\\node_modules\\**',
'C:\\Users\\remy\\node_modules\\project'); // === false
```

https://runkit.com/embed/rn05fobk294p

So this change adds the upath module (used by Chokidar during testing
and about 35K footprint) to normalize the path to bash-like slashes
which corrects the issue.