### PR TITLE
Accept upath minor and security patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "normalize-path": "^2.1.1",
     "path-is-absolute": "^1.0.0",
     "readdirp": "^2.0.0",
-    "upath": "1.0.0"
+    "upath": "^1.0.0"
   }
 }


### PR DESCRIPTION
It looks like upath was accidentally limited to only v1.0.0, since it was just added in the last release.

If you have a reason for limiting the version so specifically, that's fine. I won't be offended by a PR rejection :) I just wanted to bring it to your attention.