### PR TITLE
Unlink and re-add fails when multiple paths are passed

### DIFF
--- a/test.js
+++ b/test.js
@@ -428,7 +428,7 @@ function runTests(baseopts) {
       var unlinkSpy = sinon.spy(function unlinkSpy(){});
       var addSpy = sinon.spy(function addSpy(){});
       var testPath = getFixturePath('unlink.txt');
-      watcher = chokidar.watch(testPath, options)
+      watcher = chokidar.watch([testPath, testPath + '.does-not-exist'], options)
         .on('unlink', unlinkSpy)
         .on('add', addSpy)
         .on('ready', function() {


### PR DESCRIPTION
Adding a second path to the watcher causes it to **not** pick up a re-add after an unlink (in non-polling and polling tests, fsevents still works). I tried poking around to find a fix but I'm not too familiar with the internals so I haven't found a solution yet. Watching directories does not have this issue.

This has proved problematic developing in Linux when switching branches and using webpack. A file that exists in one branch is removed on branch change and can no longer be watched when switching back to the initial branch.