### PR TITLE
Update braces to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "anymatch": "^2.0.0",
     "async-each": "^1.0.0",
-    "braces": "^2.3.0",
+    "braces": "^2.3.1",
     "glob-parent": "^3.1.0",
     "inherits": "^2.0.1",
     "is-binary-path": "^1.0.0",


### PR DESCRIPTION
# Update braces to 2.3.1
Braces has 2.3.0 has a ReDos vulnerability: https://snyk.io/vuln/npm:braces:20180219
This is fixed 2.3.1.