### PR TITLE
Add callbacks to fs.close

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -213,9 +213,15 @@ function(watchPath, realPath, transform, globFilter) {
     }
     function checkFd() {
       fs.open(path, 'r', function(error, fd) {
-        if (fd) fs.close(fd);
-        error && error.code !== 'EACCES' ?
-          handleEvent('unlink') : addOrChange();
+        if (error) {
+          error.code !== 'EACCES' ?
+            handleEvent('unlink') : addOrChange();
+        } else {
+          fs.close(fd, function(err) {
+            err && err.code !== 'EACCES' ?
+              handleEvent('unlink') : addOrChange();
+          });
+        }
       });
     }
     // correct for wrong events emitted

--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -90,8 +90,9 @@ function setFsWatchListener(path, fullPath, options, handlers) {
       // Workaround for https://github.com/joyent/node/issues/4337
       if (process.platform === 'win32' && error.code === 'EPERM') {
         fs.open(path, 'r', function(err, fd) {
-          if (fd) fs.close(fd);
-          if (!err) broadcastErr(error);
+          if (!err) fs.close(fd, function(err) {
+            if (!err) broadcastErr(error);
+          });
         });
       } else {
         broadcastErr(error);


### PR DESCRIPTION
This also fixes an issue that using `fd = 0` is not closing so far.

Adding callbacks is important due to a soon coming [change](https://github.com/nodejs/node/pull/18668) in Node.js.