### PR TITLE
chore: upgrade to `fsevents: ^1.1.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sinon-chai": "^2.6.0"
   },
   "optionalDependencies": {
-    "fsevents": "^1.0.0"
+    "fsevents": "^1.1.2"
   },
   "dependencies": {
     "anymatch": "^2.0.0",


### PR DESCRIPTION
the `"fsevents": "^1.0.0"` will try to download [https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.1.1/fse-v1.1.1-node-v57-darwin-x64.tar.gz](https://fsevents-binaries.s3-us-west-2.amazonaws.com/v1.1.1/fse-v1.1.1-node-v57-darwin-x64.tar.gz) which 404 on S3.

 this error has since been fixed at `fsevents v1.1.2`, see [#181](https://github.com/strongloop/fsevents/issues/181)
