### PR TITLE
[wip] Add watchman backend

### DIFF
--- a/lib/watchman-handler.js
+++ b/lib/watchman-handler.js
@@ -1,0 +1,122 @@
+'use strict';
+
+var fs = require('fs');
+var sysPath = require('path');
+var anymatch = require('anymatch');
+var watchman = require('fb-watchman');
+var isGlob = require('is-glob');
+var client = new watchman.Client();
+
+// fake constructor for attaching watchman-specific prototype methods that
+// will be copied to FSWatcher's prototype
+function WatchmanHandler() {
+}
+
+var watcherId = 0;
+
+WatchmanHandler.prototype._addToWatchman = function(path) {
+  var wh = this._getWatchHelpers(path);
+  client.capabilityCheck({required: ['relative_root']}, function(error, resp) {
+    if (this._handleError(error)) {
+      return this._emitReady();
+    }
+
+    function findExistingParent(path, cb) {
+      var next = sysPath.dirname(path);
+      fs.lstat(path, function(error, stats) {
+        if (error) {
+          if (error.code === 'ENOENT') {
+            if (next === path) {
+              cb(new Error('Could not find any existing parent directory'));
+            } else {
+              findExistingParent(next, cb);
+            }
+          } else {
+            cb(error);
+          }
+        } else if (stats.isDirectory()) {
+          cb(null, path, stats);
+        } else {
+          if (next === path) {
+            cb(new Error('Could not find any parent directory'));
+          } else {
+            findExistingParent(next, cb);
+          }
+        }
+      });
+    }
+
+    var resolved = sysPath.resolve(wh.watchPath);
+    if (this._isIgnored(wh.watchPath)) return this._emitReady();
+    findExistingParent(resolved, function(error, root, stats) {
+      if (this._handleError(error)) {
+        return this._emitReady();
+      }
+
+      var relative = sysPath.relative(root, resolved);
+
+      client.command(['watch', root], function(error, resp) {
+        if (this._handleError(error)) {
+          return this._emitReady();
+        }
+        var opts = {
+          fields: ['name', 'exists', 'new', 'type'],
+        };
+        var match;
+        var glob = path.replace(root, '');
+        if (glob[0] === '/') glob = glob.slice(1);
+        if (!this.options.disableGlobbing && isGlob(glob)) {
+          match = anymatch(glob);
+        } else {
+          opts.expression = [
+            'anyof',
+            ['dirname', glob],
+            ['name', glob, 'wholename'],
+          ];
+        }
+        if (this.options.ignoreInitial) {
+          opts.empty_on_fresh_instance = true;
+        }
+
+        var subscription = 'chokidar-' + (watcherId++);
+        client.command(['subscribe', root, subscription, opts],
+            function(error, resp) {
+              if (this._handleError(error)) {
+                return this._emitReady();
+              }
+              // watchman returns the first results immediately after the
+              // subscription response. This is racy, but at least it works for
+              // the tests that requires us to emit the add events before ready.
+              process.nextTick(function() {
+                this._emitReady();
+              }.bind(this));
+            }.bind(this));
+        var listener = function(resp) {
+          if (resp.subscription !== subscription) return;
+          resp.files.forEach(function(entry) {
+            if (!match || match(entry.name)) {
+              this.emit('raw', resp);
+              var eventName = entry.exists ?
+                  (entry.new ? 'add' : 'change') :
+                  'unlink';
+              if (eventName !== 'change' && entry.type ===
+                  'd') eventName += 'Dir';
+              var absPath = sysPath.join(root, entry.name);
+              if (!this._isIgnored(absPath)) {
+                this._emit(eventName, absPath);
+              }
+            }
+          }.bind(this));
+        }.bind(this);
+        client.on('subscription', listener);
+
+        this._closers[root] = function() {
+          client.removeListener('subscription', listener);
+          client.command(['unsubscribe', root, subscription]);
+        };
+      }.bind(this));
+    }.bind(this));
+  }.bind(this));
+};
+
+module.exports = WatchmanHandler;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "anymatch": "^2.0.0",
     "async-each": "^1.0.0",
     "braces": "^2.3.0",
+    "fb-watchman": "^2.0.0",
     "glob-parent": "^3.1.0",
     "inherits": "^2.0.1",
     "is-binary-path": "^1.0.0",

--- a/test.js
+++ b/test.js
@@ -117,6 +117,7 @@ describe('chokidar', function() {
     describe('fs.watch (non-polling)', runTests.bind(this, {usePolling: false, useFsEvents: false}));
   }
   describe('fs.watchFile (polling)', runTests.bind(this, {usePolling: true, interval: 10}));
+  describe('fs.watch (watchman)', runTests.bind(this, {usePolling: false, useFsEvents: false, useWatchman: true}));
 });
 
 function simpleCb(err) { if (err) throw err; }
@@ -808,6 +809,8 @@ function runTests(baseopts) {
   });
   describe('watch symlinks', function() {
     if (os === 'win32') return;
+    if (baseopts.useWatchman) return;
+
     before(closeWatchers);
     var linkedDir;
     beforeEach(function(done) {


### PR DESCRIPTION
This is an experimental backend for watchman mainly intended for being overriden by the user. watchman is a robust and resource efficient file-watching server, which can be used for sharing inotify watches to avoid creating too much file descriptors.

We probably want to allow the user to specify the workspace root so we don't watch many subdirs.

69/90 test passing currently; globbing and unwatching has issues. symlinks are not supported at all, so its tests are disabled. Also, CI is currently left broken because watchman needs manual installation ([example](https://github.com/researchgate/webpack-watchman-plugin/blob/796a712b51647fc236798fa6c8a70193ac741e95/.travis.yml)).

Close #486 
