### PR TITLE
don't use broken fsevents release

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sinon-chai": "^2.6.0"
   },
   "optionalDependencies": {
-    "fsevents": "^1.1.2"
+    "fsevents": "^1.2.2"
   },
   "dependencies": {
     "anymatch": "^2.0.0",


### PR DESCRIPTION
Hi there,

We've had some broken builds today using Chokidar because of a broken `fsevents` release. This PR ensures that we're using at least https://github.com/strongloop/fsevents/releases/tag/v1.2.2

All best,
Ben