### PR TITLE
update upath version to avoid install errors on node v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "normalize-path": "^2.1.1",
     "path-is-absolute": "^1.0.0",
     "readdirp": "^2.0.0",
-    "upath": "^1.0.0"
+    "upath": "^1.0.5"
   }
 }


### PR DESCRIPTION
upath versions lower than 1.0.5 fail to install on node v10