### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ test-fixtures
 coverage
 *.bak
 *.log
+.nyc_output
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 test-fixtures
-coverage
 *.bak
 *.log
 .nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ os:
   - linux
   - osx
 script:
-  - npm run ci-test
+  - npm run test
 after_script:
   - npm run coveralls
 sudo: false

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "scripts": {
     "test": "nyc mocha --exit",
-    "coveralls": "cat ./coverage/lcov.info | coveralls"
+    "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "test": "istanbul test node_modules/mocha/bin/_mocha",
+    "test": "nyc mocha --exit",
     "ci-test": "istanbul cover _mocha",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
@@ -34,8 +34,8 @@
     "chai": "^3.2.0",
     "coveralls": "^3.0.1",
     "graceful-fs": "4.1.4",
-    "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
+    "nyc": "^11.8.0",
     "rimraf": "^2.4.3",
     "sinon": "^1.10.3",
     "sinon-chai": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "license": "MIT",
   "scripts": {
     "test": "nyc mocha --exit",
-    "ci-test": "istanbul cover _mocha",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   ],
   "devDependencies": {
     "chai": "^3.2.0",
-    "coveralls": "^2.11.2",
+    "coveralls": "^3.0.1",
     "graceful-fs": "4.1.4",
-    "istanbul": "^0.3.20",
-    "mocha": "^3.0.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^5.2.0",
     "rimraf": "^2.4.3",
     "sinon": "^1.10.3",
     "sinon-chai": "^2.6.0"


### PR DESCRIPTION
This fixes #715 related to security vulnerabilities reported by `npm audit`.

I've replaced `istanbul` by `nyc` (which is the latest version of `istanbul`).

I'm going to need some help with this PR for the following reasons:
  - 3 tests failed before I start this PR (i.e. not related to it), and still fail afterwards. That's why CI fails.
  - `mocha` hangs after testing. I'm not sure whether it's because of improper teardown in tests, or because of those failing tests. I've added the `--exit` flag to Mocha, which fixes the problem for the moment.
  - I don't have access to Coveralls, so I cannot make sure it works there (although it should)