### PR TITLE
Don't fs.FSWatcher.close() after a remove if Windows and Node >= 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -574,13 +574,15 @@ FSWatcher.prototype._remove = function(directory, item) {
 
   // Avoid conflicts if we later create another file with the same name
   if (!this.options.useFsEvents) {
-    this._closePath(path);
+    this._closePath(path, true);
   }
 };
 
-FSWatcher.prototype._closePath = function(path) {
+// * afterRemove - optional boolean, to avoid closing fs.FSWatcher if it would crash
+
+FSWatcher.prototype._closePath = function(path, afterRemove) {
   if (!this._closers[path]) return;
-  this._closers[path]();
+  this._closers[path](afterRemove);
   delete this._closers[path];
   this._getWatchedDir(sysPath.dirname(path)).remove(sysPath.basename(path));
 }

--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -111,14 +111,20 @@ function setFsWatchListener(path, fullPath, options, handlers) {
   }
   var listenerIndex = container.listeners.length - 1;
 
+  // * afterRemove - optional boolean, to avoid closing fs.FSWatcher if it would crash
+
   // removes this instance's listeners and closes the underlying fs.watch
   // instance if there are no more listeners left
-  return function close() {
+  return function close(afterRemove) {
     delete container.listeners[listenerIndex];
     delete container.errHandlers[listenerIndex];
     delete container.rawEmitters[listenerIndex];
     if (!Object.keys(container.listeners).length) {
-      container.watcher.close();
+      // close unless Windows, Node >= 10, and afterRemove,
+      // see https://github.com/paulmillr/chokidar/issues/730
+      if (!(process.platform === 'win32' && Number(process.versions.node.match(/[0-9]+/)[0]) >= 10) || !afterRemove) {
+        container.watcher.close();
+      }
       delete FsWatchInstances[fullPath];
     }
   };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "coveralls": "^3.0.1",
+    "fs-extra": "^6.0.1",
     "graceful-fs": "4.1.4",
     "mocha": "^5.2.0",
     "nyc": "^11.8.0",


### PR DESCRIPTION
Could not tell whether this is the best possible fix for issue #730, but so far this apparently prevents crashes in some apps.

Submitting pull request to move towards being able to run apps without crashing.

Welcome discussion.