### PR TITLE
chore(deps): updated dep for compatibility node10

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "normalize-path": "^2.1.1",
     "path-is-absolute": "^1.0.0",
     "readdirp": "^2.0.0",
-    "upath": "^1.0.5"
+    "upath": "^1.1.0"
   }
 }


### PR DESCRIPTION
Since the 1.1.0 release of upath the engine requirement `<=9` has been deleted. This 1.1.0 release is/was not covered with the caret version range. 

This PR updates the dependency to make babel 7 compatible with node version above 10 
(Babel 7 uses chokidar as a dependency and using babel with node 10 and above results in an error, which this PR should resolve)