### PR TITLE
Bump upath from 1.0.5 to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "normalize-path": "^2.1.1",
     "path-is-absolute": "^1.0.0",
     "readdirp": "^2.0.0",
-    "upath": "^1.0.5"
+    "upath": "^1.1.0"
   }
 }


### PR DESCRIPTION
Without `upath@1.1.0` chokidar [cannot run on node 10](https://github.com/anodynos/upath/commit/8c5f4e10376ed1cd4553d9432297d39a34410c69).