### PR TITLE
Update fsevents dependency to use napi

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -25,7 +25,8 @@ var consolidateThreshhold = 10;
 
 // Returns new fsevents instance
 function createFSEventsInstance(path, callback) {
-  return (new fsevents(path)).on('fsevent', callback).start();
+  const stop = fsevents.watch(path, callback);
+  return { stop };
 }
 
 // Private function: Instantiates the fsevents interface or binds listeners

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chokidar",
   "description": "A neat wrapper around node.js fs.watch / fs.watchFile / fsevents.",
-  "version": "2.0.4",
+  "version": "2.0.5-pre-1",
   "keywords": [
     "fs",
     "watch",
@@ -40,7 +40,7 @@
     "sinon-chai": "^2.6.0"
   },
   "optionalDependencies": {
-    "fsevents": "^1.2.2"
+    "fsevents": "napi"
   },
   "dependencies": {
     "anymatch": "^2.0.0",


### PR DESCRIPTION
This updated the *fsevents* dependency to use the napi tagged version (currently 2.0.2-pre-1)

There are a few API changes, and support for *node*-versions below v8 has been dropped, whence the major version bump. (v8.x support is not there currently but will become available through https://github.com/nodejs/node/pull/25002)

The big advantage of this is that *fsevents* is now using *N-API* which means a single build works with all versions of *node*. No more *node-pre-gyp* downloading specific versions and upgrading with every new *node* release.

In addition fsevents now uses a single runloop/thread to listen for events which makes it significantly cheaper; and it reduces the API to just handle the native stuff, which is all *chokidar* uses which leads to eliminating a `stat` call per event, again making it a lot cheaper.

I have also tested the regular binary against the upcoming version of *electron* (v4.0.0-beta7) and it works out of the box. So this should also eliminate some of the pain associated with that.