### PR TITLE
Remove unused lodash.debounce dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "inherits": "^2.0.1",
     "is-binary-path": "^1.0.0",
     "is-glob": "^4.0.0",
-    "lodash.debounce": "^4.0.8",
     "normalize-path": "^2.1.1",
     "path-is-absolute": "^1.0.0",
     "readdirp": "^2.0.0",


### PR DESCRIPTION
Fixes https://github.com/paulmillr/chokidar/issues/772 and https://github.com/paulmillr/chokidar/issues/785

Looks like the lodash.debounce changes were rolled back in this commit https://github.com/paulmillr/chokidar/commit/28a70c40e6ca0d4a39fa1f53ec7ca0a165cb4b36#diff-a211b3645e08f044b3d64f65bbcabac9 but the package.json was missed.