### PR TITLE
always fire "changed" event if mtime has been changed

### DIFF
--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -11,10 +11,6 @@ var isBinaryPath = require('is-binary-path');
 // (may be shared across chokidar FSWatcher instances)
 var FsWatchInstances = Object.create(null);
 
-// atime and mtime are changing simultaneously by OS
-// so we need threshold (in ms) to understand when file is changed
-// or when only atime is updated (which we want to ignore)
-var accessTimeDelayThreshold = 1000;
 
 // Private function: Instantiates the fs.watch interface
 
@@ -256,6 +252,8 @@ function(file, stats, initialAdd, callback) {
   var dirname = sysPath.dirname(file);
   var basename = sysPath.basename(file);
   var parent = this._getWatchedDir(dirname);
+  // stats is always present
+  var prevStats = stats;
 
   // if the file is already being watched, do nothing
   if (parent.has(basename)) return callback();
@@ -269,22 +267,24 @@ function(file, stats, initialAdd, callback) {
         if (error) {
           this._remove(dirname, basename);
         } else {
-          // Check that change event was not fired because of changed accessTime.
+          // Check that change event was not fired because of changed only accessTime.
           var at = newStats.atime.getTime();
           var mt = newStats.mtime.getTime();
-          if (!at || at <= mt || (at - mt) <= accessTimeDelayThreshold) {
+          if (!at || at <= mt || mt !== prevStats.mtime.getTime()) {
             this._emit('change', file, newStats);
           }
+          prevStats = newStats;
         }
       }.bind(this));
     // add is about to be emitted if file not already tracked in parent
     } else if (parent.has(basename)) {
-      // Check that change event was not fired because of changed accessTime.
+      // Check that change event was not fired because of changed only accessTime.
       var at = newStats.atime.getTime();
       var mt = newStats.mtime.getTime();
-      if (!at || at <= mt || (at - mt) <= accessTimeDelayThreshold) {
+      if (!at || at <= mt ||  mt !== prevStats.mtime.getTime()) {
         this._emit('change', file, newStats);
       }
+      prevStats = newStats;
     }
   }.bind(this));
 


### PR DESCRIPTION
Checked that original issue (that Windows update `atime` and fire FS notification) still fixed.
Also verified that `usePolling: true` is wokring.