### PR TITLE
fix #806: Chokidar doesn't let process exit when watching globs with subfolders

### DIFF
--- a/index.js
+++ b/index.js
@@ -580,7 +580,9 @@ FSWatcher.prototype._remove = function(directory, item) {
 
 FSWatcher.prototype._closePath = function(path) {
   if (!this._closers[path]) return;
-  this._closers[path]();
+  this._closers[path].forEach(function(closer) {
+    closer();
+  });
   delete this._closers[path];
   this._getWatchedDir(sysPath.dirname(path)).remove(sysPath.basename(path));
 }
@@ -699,7 +701,9 @@ FSWatcher.prototype.close = function() {
 
   this.closed = true;
   Object.keys(this._closers).forEach(function(watchPath) {
-    this._closers[watchPath]();
+    this._closers[watchPath].forEach(function(closer) {
+      closer();
+    });
     delete this._closers[watchPath];
   }, this);
   this._watched = Object.create(null);

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -389,7 +389,10 @@ function(path, transform, forceAdd, priorDepth) {
         processPath,
         wh.globFilter
       );
-      if (closer) this._closers[path] = closer;
+      if (closer) {
+        this._closers[path] = this._closers[path] || [];
+        this._closers[path].push(closer);
+      }
     }.bind(this);
 
     if (typeof transform === 'function') {

--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -495,7 +495,10 @@ function(path, initialAdd, priorWh, depth, target, callback) {
       closer = this._handleFile(wh.watchPath, stats, initialAdd, ready);
     }
 
-    if (closer) this._closers[path] = closer;
+    if (closer) {
+      this._closers[path] = this._closers[path] || [];
+      this._closers[path].push(closer);
+    }
     callback(null, false);
   }.bind(this));
 };


### PR DESCRIPTION
This is a simple change. I noticed that when some patterns needed to watch for different files in the same directory, a single watcher could add multiple listeners on the same directory.

They all need to be closed and not only one because if not the listeners count never gets to `0` and the underlying `fs.watch` watcher is never disposed.

Since I don't know well the overall codebase I don't know if it's normal that a single chokidar watcher does multiple calls to `setFsWatchListener` with the same `path` but it obviously does.