### PR TITLE
Error and Skip for Dangling Symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ instantiating the watching as chokidar discovers these file paths (before the `r
 * `followSymlinks` (default: `true`). When `false`, only the
 symlinks themselves will be watched for changes instead of following
 the link references and bubbling events through the link's path.
+* `reportErrorOnDanglingSymlinks` (default: `false`) When `followSymlinks: true`, Chokidar silently waits for paths under 
+dangling symlinks to be created. The user might instead want to confine Chokidar to wait for explicitly specified paths only. 
+When set to `true`, the dangling symlink is reported as an error instead and the absence of underlying symlinked path 
+ is ignored.
 * `cwd` (no default). The base directory from which watch `paths` are to be
 derived. Paths emitted with events will be relative to this.
 * `disableGlobbing` (default: `false`). If set to `true` then the strings passed to `.watch()` and `.add()` are treated as

--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -515,8 +515,8 @@ async _addToNodeFs(path, initialAdd, priorWh, depth, target) {
 
   // evaluate what is at the path we're being asked to watch
   try {
-    const stats = await statMethods[wh.statMethod](wh.watchPath);
-    if (this.fsw._isIgnored(wh.watchPath, stats)) {
+    const stats = await statMethods[wh.statMethod](wh.watchPath); 
+    if (this.fsw._isIgnored(wh.watchPath, stats)) { 
       ready();
       return false;
     }
@@ -547,8 +547,16 @@ async _addToNodeFs(path, initialAdd, priorWh, depth, target) {
     this.fsw._addPathCloser(path, closer);
     return false;
 
-  } catch (error) {
-    if (this.fsw._handleError(error)) return path;
+  } catch (error) { 
+    if (this.fsw._handleError(error)) { 
+      // If path is a symlink, test if the error is due to a dangling symlink
+      // Based on the options user might want to report it and move on 
+      // (rather than having to wait for the path to be recreated)
+      if (this.fsw._symlinkPaths.has(wh.watchPath)) { 
+        if (this.fsw._handleDanglingSymlinkError(error)) ready();
+      } 
+      return path;
+    }  
   }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -94,6 +94,15 @@ export interface WatchOptions {
   followSymlinks?: boolean;
 
   /**
+   * When `followSymlinks: true`, Chokidar silently waits for paths under dangling symlinks to be
+   * created. The user might instead want to confine themselves to watch explicitly specified paths. 
+   * 
+   * If set to `true`, the dangling symlink is reported as an error and Chokidar ignores  
+   * the absence of the underlying path. 
+   */
+  reportErrorOnDanglingSymlinks?: boolean;
+
+  /**
    * The base directory from which watch `paths` are to be derived. Paths emitted with events will
    * be relative to this.
    */


### PR DESCRIPTION
This is an obviously incorrect PR. The changes here come with a generous dose of hocus-pocus. I do not fully understand what I am doing but it just works. I am hoping that this will prompt an eventual fix to #469 which now seems to be affecting other people as well.

I have not written any test (only tested the change manually). The test file is so long and dense that it makes me giddy...

Adds a `reportErrorOnDanglingSymlink` option that leads error message when a symlink is found to be dangling. It skips waiting for the underlying path to be created. With this change a dangling symlink will not block the `ready` event, if so desired by the user.