### PR TITLE
Error and Skip for Dangling Symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ instantiating the watching as chokidar discovers these file paths (before the `r
 * `followSymlinks` (default: `true`). When `false`, only the
 symlinks themselves will be watched for changes instead of following
 the link references and bubbling events through the link's path.
+* `reportErrorOnDanglingSymlinks` (default: `false`) When `followSymlinks: true`, Chokidar silently waits for paths under 
+dangling symlinks to be created. The user might instead want to confine Chokidar to wait for explicitly specified paths only. 
+When set to `true`, the dangling symlink is reported as an error instead and the absence of underlying symlinked path 
+ is ignored.
 * `cwd` (no default). The base directory from which watch `paths` are to be
 derived. Paths emitted with events will be relative to this.
 * `disableGlobbing` (default: `false`). If set to `true` then the strings passed to `.watch()` and `.add()` are treated as

--- a/index.js
+++ b/index.js
@@ -287,6 +287,9 @@ constructor(_opts) {
   if (opts.atomic) this._pendingUnlinks = new Map();
 
   if (undef(opts, 'followSymlinks')) opts.followSymlinks = true;
+  
+  if (undef(opts, 'reportErrorOnDanglingSymlinks')) opts.reportErrorOnDanglingSymlinks = false;
+  if (!opts.followSymlinks) opts.reportErrorOnDanglingSymlinks = false;
 
   if (undef(opts, 'awaitWriteFinish')) opts.awaitWriteFinish = false;
   if (opts.awaitWriteFinish === true) opts.awaitWriteFinish = {};
@@ -588,6 +591,21 @@ _handleError(error) {
   }
   return error || this.closed;
 }
+
+/**
+ * Special handler for dangling symlink errors
+ * @param {Error} error
+ * @returns {Boolean} True if Dangling conditions are met
+ */
+_handleDanglingSymlinkError(error) {
+  const code = error && error.code;
+  if (error && this.options.reportErrorOnDanglingSymlinks && code === 'ENOENT') {
+    error.message = `Dangling Symlink: ${error.message}`;
+    this.emit('error', error);
+    return true;
+  }
+}
+
 
 /**
  * Helper utility for throttling

--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -548,7 +548,15 @@ async _addToNodeFs(path, initialAdd, priorWh, depth, target) {
     return false;
 
   } catch (error) {
-    if (this.fsw._handleError(error)) return path;
+    if (this.fsw._handleError(error)) {
+      // If path is a symlink, test if the error is due to a dangling symlink
+      // Based on the options user might want to report it and move on
+      // (rather than having to wait for the path to be recreated)
+      if (this.fsw._symlinkPaths.has(wh.watchPath)) {
+        if (this.fsw._handleDanglingSymlinkError(error)) ready();
+      }
+      return path;
+    }
   }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -94,6 +94,15 @@ export interface WatchOptions {
   followSymlinks?: boolean;
 
   /**
+   * When `followSymlinks: true`, Chokidar silently waits for paths under dangling symlinks to be
+   * created. The user might instead want to confine themselves to watch explicitly specified paths.
+   *
+   * If set to `true`, the dangling symlink is reported as an error and Chokidar ignores  
+   * the absence of the underlying path.
+   */
+  reportErrorOnDanglingSymlinks?: boolean;
+
+  /**
    * The base directory from which watch `paths` are to be derived. Paths emitted with events will
    * be relative to this.
    */


### PR DESCRIPTION
This is an obviously incorrect PR (and a second attempt at it). The changes here come with a generous dose of hocus-pocus. I do not fully understand what I am doing but it just works. However I am not sure if it deals with the side effects (e.g. What should happen if the path is recreated or symlink is deleted or linked path is changed? Does the change affect close in some way?). I am hoping that this will prompt an eventual fix to #469 which now seems to be affecting other people as well.

I have not written any test (only tested the change manually). The test file is so long and dense that it makes me giddy. 

The existing tests sometimes pass and sometimes fail. Though I believe the failure is unrelated to changes here:
```
1) chokidar
       fs.watch (non-polling)
         watch glob patterns
           should correctly handle intersecting glob patterns:
     expected spy to have been called exactly twice, but it was called thrice
    spy(add, ~\libs\chokidar\test-fixtures\30\change.txt,
```

Coveralls did complain that the tests are failing in my first attempt, but I do not get those particular errors when testing locally (mind you I am testing on a Windows machine).

Adds a `reportErrorOnDanglingSymlink` option that leads error message when a symlink is found to be dangling. It skips waiting for the underlying path to be created. With this change a dangling symlink will not block the `ready` event, if so desired by the user.