### PR TITLE
add call to ready() when an error is handled in _addToNodeFs()

### DIFF
--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -563,7 +563,10 @@ async _addToNodeFs(path, initialAdd, priorWh, depth, target) {
     return false;
 
   } catch (error) {
-    if (this.fsw._handleError(error)) return path;
+    if (this.fsw._handleError(error)) {
+      ready();
+      return path;
+    }
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -1133,6 +1133,17 @@ const runTests = function(baseopts) {
       await waitFor([[addSpy, 4]]);
       addSpy.should.have.been.calledWith(sysPath.join(watchDir, 'add.txt'));
     });
+    it('should emit ready event even when broken symlinks are encountered', async () => {
+      const targetDir = getFixturePath('subdir/nonexistent');
+      await fs_mkdir(targetDir);
+      await fs_symlink(targetDir, getFixturePath('subdir/broken'));
+      await fs_rmdir(targetDir);
+      const readySpy = sinon.spy(function readySpy(){});
+      let watcher = chokidar_watch(getFixturePath('subdir'), options)
+          .on('ready', readySpy);
+      await waitForWatcher(watcher);
+      readySpy.should.have.been.calledOnce;
+    });
   });
   describe('watch arrays of paths/globs', () => {
     it('should watch all paths in an array', async () => {


### PR DESCRIPTION
I've encountered #469 on my linux laptop, I can see that when broken symlink is added in [_addToNodeFs](https://github.com/paulmillr/chokidar/blob/master/lib/nodefs-handler.js#L513), `_incrReadyCount()` is called when symlink entry is read in `_handleRead()`, but then ENOENT exception is thrown which bypasses the call to [`ready()`](https://github.com/paulmillr/chokidar/blob/master/lib/nodefs-handler.js#L560) in `_addToNodeFs`.

The result is that `ready` event is never emitted.

This adds calls to `ready()` if the error is handled in `_addToNodeFs()`, in a way similar to [this code](https://github.com/paulmillr/chokidar/blob/master/lib/fsevents-handler.js#L464) in  `fsevens-handler`.

There's also one test for `ready` event with broken symlinks added in this PR.

