### PR TITLE
refine types: arrays may be readonly

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,13 +17,13 @@ export class FSWatcher extends EventEmitter implements fs.FSWatcher {
    * Add files, directories, or glob patterns for tracking. Takes an array of strings or just one
    * string.
    */
-  add(paths: string | string[]): void;
+  add(paths: string | ReadonlyArray<string>): void;
 
   /**
    * Stop watching files, directories, or glob patterns. Takes an array of strings or just one
    * string.
    */
-  unwatch(paths: string | string[]): void;
+  unwatch(paths: string | ReadonlyArray<string>): void;
 
   /**
    * Returns an object representing all the paths on the file system being watched by this
@@ -182,6 +182,6 @@ export interface AwaitWriteFinishOptions {
  * produces an instance of `FSWatcher`.
  */
 export function watch(
-  paths: string | string[],
+  paths: string | ReadonlyArray<string>,
   options?: WatchOptions
 ): FSWatcher;

--- a/types/test.ts
+++ b/types/test.ts
@@ -58,3 +58,9 @@ chokidar
   .on("all", (event: string, path: string) => {
     console.log(event, path);
   });
+
+// watch an (readonly-) array of files
+const files: ReadonlyArray<string> = ["a", "b"];
+const watcher2 = chokidar.watch(files);
+watcher2.add(["c", "d"] as ReadonlyArray<string>);
+watcher2.unwatch(["b"] as ReadonlyArray<string>);


### PR DESCRIPTION
Hey,

I started using this fine module in a typescript project with lint-rules that enforce the usage of readonly-arrays. Chokidar's types expects mutable arrays, and checking the source-code readonly-arrays should be totally ok, so it's only the types that are too broad.