### PR TITLE
refine types: arrays may be readonly

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,13 +17,13 @@ export class FSWatcher extends EventEmitter implements fs.FSWatcher {
    * Add files, directories, or glob patterns for tracking. Takes an array of strings or just one
    * string.
    */
-  add(paths: string | string[]): void;
+  add(paths: string | ReadonlyArray<string>): void;
 
   /**
    * Stop watching files, directories, or glob patterns. Takes an array of strings or just one
    * string.
    */
-  unwatch(paths: string | string[]): void;
+  unwatch(paths: string | ReadonlyArray<string>): void;
 
   /**
    * Returns an object representing all the paths on the file system being watched by this
@@ -182,6 +182,6 @@ export interface AwaitWriteFinishOptions {
  * produces an instance of `FSWatcher`.
  */
 export function watch(
-  paths: string | string[],
+  paths: string | ReadonlyArray<string>,
   options?: WatchOptions
 ): FSWatcher;

--- a/types/test.ts
+++ b/types/test.ts
@@ -58,3 +58,18 @@ chokidar
   .on("all", (event: string, path: string) => {
     console.log(event, path);
   });
+
+// test readonly arrays
+const listOfFiles = ["a", "b"];
+const readonlyFiles: ReadonlyArray<string> = listOfFiles;
+
+const readonlyInputWatcher = chokidar.watch(readonlyFiles);
+const mutableInputWatcher = chokidar.watch(listOfFiles);
+
+const anotherListOfFiles = ["c", "d"];
+const anotherReadonlyList: ReadonlyArray<string> = anotherListOfFiles;
+
+readonlyInputWatcher.add(anotherReadonlyList);
+mutableInputWatcher.add(anotherListOfFiles);
+
+readonlyInputWatcher.unwatch(["b"] as ReadonlyArray<string>);


### PR DESCRIPTION
chokidar does not modify passed arrays, thus they may also be marked as readonly in type definition.