### PR TITLE
using bash as the shell runner (runs tests on Windows)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,6 +18,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
+      shell: bash
       run: |
         npm install
         npm run build --if-present


### PR DESCRIPTION
Currently, on Windows, the tests never run. The script only executes `npm install` and then exits. It's a common problem on various CIs, including GitHub Actions, Azure, AppVeyor, etc., needing to execute all lines with `call` prepended.

However, since this build was transitioned from Travis, where Windows builds run in gitbash, I did the same update here to run all builds in bash. On Linux and MacOS, that is already the default, and on Windows, that executes in gitbash, same as Travis.