### PR TITLE
allow watch for recursive not existing folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -770,11 +770,11 @@ _isntIgnored(path, stat) {
  */
 async _getWatchHelpers(path, depth)
 {
-  let watchPath = depth || this.options.disableGlobbing || !isGlob(path) ? path : globParent(path);
-
+  const baseWatchPath = depth || this.options.disableGlobbing || !isGlob(path) ? path : globParent(path);
   const follow = this.options.followSymlinks;
-  watchPath=await this._mostSpecifiedExistingAncestor(watchPath);
-  return new WatchHelper(path, watchPath, follow, this);
+  const existingWatchPath=await this._mostSpecifiedExistingAncestor(baseWatchPath);
+
+  return new WatchHelper(path, existingWatchPath, follow, this);
 }
 
   /**
@@ -784,18 +784,18 @@ async _getWatchHelpers(path, depth)
    * @private
    */
   async _mostSpecifiedExistingAncestor(path)
-{
-  let father=globParent(path);
+  {
+      const father = globParent(path);
 
-  if(father==path)
-    return path;
+      if (father == path)
+          return path;
 
-  const doesExists=await exists(path);
-  if(doesExists)
-    return path;
+      const doesExists = await exists(path);
+      if (doesExists)
+          return path;
 
-  return this._mostSpecifiedExistingAncestor(father);
-}
+      return this._mostSpecifiedExistingAncestor(father);
+  }
 
 // Directory helpers
 // -----------------

--- a/index.js
+++ b/index.js
@@ -766,9 +766,10 @@ _isntIgnored(path, stat) {
  * Provides a set of common helpers and properties relating to symlink and glob handling.
  * @param {Path} path file, directory, or glob pattern being watched
  * @param {Number=} depth at any depth > 0, this isn't a glob
- * @returns {WatchHelper} object containing helpers for this path
+ * @returns {Promise<WatchHelper>} object containing helpers for this path
  */
-async _getWatchHelpers(path, depth) {
+async _getWatchHelpers(path, depth)
+{
   let watchPath = depth || this.options.disableGlobbing || !isGlob(path) ? path : globParent(path);
 
   const follow = this.options.followSymlinks;

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -433,7 +433,7 @@ async _addToFsEvents(path, transform, forceAdd, priorDepth) {
   const opts = this.fsw.options;
   const processPath = typeof transform === FUNCTION_TYPE ? transform : IDENTITY_FN;
 
-  const wh = this.fsw._getWatchHelpers(path);
+  const wh = await this.fsw._getWatchHelpers(path);
 
   // evaluate what is at the path we're being asked to watch
   try {

--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -570,7 +570,7 @@ async _addToNodeFs(path, initialAdd, priorWh, depth, target) {
     return false;
   }
 
-  let wh = this.fsw._getWatchHelpers(path, depth);
+  let wh =await this.fsw._getWatchHelpers(path, depth);
   if (!wh.hasGlob && priorWh) {
     wh.hasGlob = priorWh.hasGlob;
     wh.globFilter = priorWh.globFilter;

--- a/test.js
+++ b/test.js
@@ -744,6 +744,53 @@ const runTests = function(baseopts) {
       spy.should.have.been.calledWith('add', testPath);
     });
   });
+
+    it('should watch glob path with  non-existent dir and detect addDir/add', async () => {
+        const testDir = getFixturePath('subdir');
+        const testPathWithGlob=getFixturePath("subdir/*.txt")
+        const testPath = getFixturePath('subdir/add.txt');
+        let watcher = chokidar_watch(testPathWithGlob, options);
+        const spy = await aspy(watcher, 'all');
+        spy.should.not.have.been.called;
+
+        await delay();
+        await fs_mkdir(testDir, PERM_ARR);
+
+        await delay();
+        await write(testPath, 'hello');
+        await waitFor([spy.withArgs('add')]);
+      spy.should.not.have.been.calledWith('addDir', testDir);
+      spy.should.have.been.calledWith('add', testPath);
+    });
+
+  it('should watch glob path with  non-existent dir and detect addDir/add', async function  ()  {
+    function skipIfCantRun() {
+      let currentNodeVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1])
+      if (currentNodeVersion < 10.12)
+        this.skip("recursive mkdir  is not supported before node 10.12")
+    }
+
+    skipIfCantRun.call(this);
+    const subPath = 'subdir0/subdir1/subdir2/subdir3';
+    const testDir = getFixturePath(subPath);
+    const testPathWithGlob=getFixturePath(subPath+"/*.txt")
+    const testPath = getFixturePath(subPath+'/add.txt');
+    let watcher = chokidar_watch(testPathWithGlob, options);
+    const spy = await aspy(watcher, 'all');
+    spy.should.not.have.been.called;
+
+    await delay();
+    await fs_mkdir(testDir, {recursive:true,mode:PERM_ARR});
+
+    await delay();
+    await write(testPath, 'hello');
+    await waitFor([spy.withArgs('add')]);
+    spy.should.not.have.been.calledWith('addDir');
+    spy.should.have.been.calledWith('add', testPath);
+  });
+
+
+
   describe('watch glob patterns', () => {
     it('should correctly watch and emit based on glob input', async () => {
       const watchPath = getGlobPath('*a*.txt');


### PR DESCRIPTION
Solves #872 

This pull request allows user to watch specific not existing folders.
Was achieved via introducing a new function _mostSpecifiedExistingAncestor
We should consider making  the function public, as users might be interested in this functionality.