### PR TITLE
requiring a new minimum of fsevents

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "readdirp": "~3.2.0"
   },
   "optionalDependencies": {
-    "fsevents": "~2.1.0"
+    "fsevents": "~2.1.1"
   },
   "devDependencies": {
     "@types/node": "^12",


### PR DESCRIPTION
Making sure that anyone installing chokidar gets the new version of fsevents which fixes random thread hanging: https://github.com/fsevents/fsevents/pull/290

This helps projects who have a package lock or yarn lock file update their dependencies, as sub-dependencies are not always updated when the existing one matches the semver string.

This resolves #873 