### PR TITLE
Update nodejs.yml

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,5 +21,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - name: Run tests
-        shell: bash
         run: npm test


### PR DESCRIPTION
Remove bash on Windows; it's not needed

I tested this on my Windows 10 machine with Windows cmd, and bash isn't needed.