### PR TITLE
Lint codebase

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-global.watcher = require('./').watch('.', {
+global.watcher = require('.').watch('.', {
   ignored: /node_modules|\.git/,
   persistent: true,
   // followSymlinks: false,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const {sep} = require('path');
 
 exports.EV_ALL = 'all';
@@ -28,13 +30,13 @@ exports.KEY_ERR = 'errHandlers';
 exports.KEY_RAW = 'rawEmitters';
 exports.HANDLER_KEYS = [exports.KEY_LISTENERS, exports.KEY_ERR, exports.KEY_RAW];
 
-exports.DOT_SLASH = '.' + sep;
+exports.DOT_SLASH = `.${sep}`;
 
 exports.BACK_SLASH_RE = /\\/g;
 exports.DOUBLE_SLASH_RE = /\/\//;
-exports.SLASH_OR_BACK_SLASH_RE = /[\/\\]/;
-exports.DOT_RE = /\..*\.(sw[px])$|\~$|\.subl.*\.tmp/;
-exports.REPLACER_RE = /^\.[\/\\]/;
+exports.SLASH_OR_BACK_SLASH_RE = /[/\\]/;
+exports.DOT_RE = /\..*\.(sw[px])$|~$|\.subl.*\.tmp/;
+exports.REPLACER_RE = /^\.[/\\]/;
 
 exports.SLASH = '/';
 exports.BRACE_START = '{';
@@ -50,7 +52,7 @@ exports.STRING_TYPE = 'string';
 exports.FUNCTION_TYPE = 'function';
 exports.EMPTY_STR = '';
 exports.EMPTY_FN = () => {};
-exports.IDENTITY_FN = (val => val);
+exports.IDENTITY_FN = val => val;
 
 const {platform} = process;
 exports.isWindows = platform === 'win32';

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -11,10 +11,10 @@ try { fsevents = require('fsevents'); } catch (error) {
 
 if (fsevents) {
   // TODO: real check
-  let mtch = process.version.match(/v(\d+)\.(\d+)/);
+  const mtch = process.version.match(/v(\d+)\.(\d+)/);
   if (mtch && mtch[1] && mtch[2]) {
-    let maj = Number.parseInt(mtch[1]);
-    let min = Number.parseInt(mtch[2]);
+    const maj = Number.parseInt(mtch[1], 10);
+    const min = Number.parseInt(mtch[2], 10);
     if (maj === 8 && min < 16) {
       fsevents = undefined;
     }
@@ -144,7 +144,7 @@ function setFSEventsListener(path, realPath, listener, rawEmitter, fsw) {
   } else {
     cont = {
       listeners: new Set([filteredListener]),
-      rawEmitter: rawEmitter,
+      rawEmitter,
       watcher: createFSEventsInstance(watchPath, (fullPath, flags) => {
         if (fsw.closed) return;
         const info = fsevents.getInfo(fullPath, flags);
@@ -218,10 +218,10 @@ checkIgnored(path, stats) {
       ipaths.add(path + ROOT_GLOBSTAR);
     }
     return true;
-  } else {
-    ipaths.delete(path);
-    ipaths.delete(path + ROOT_GLOBSTAR);
   }
+
+  ipaths.delete(path);
+  ipaths.delete(path + ROOT_GLOBSTAR);
 }
 
 addOrChange(path, fullPath, realPath, parent, watchedDir, item, info, opts) {
@@ -263,11 +263,11 @@ handleEvent(event, path, fullPath, realPath, parent, watchedDir, item, info, opt
         const curDepth = opts.depth === undefined ?
           undefined : calcDepth(fullPath, realPath) + 1;
         return this._addToFsEvents(path, false, true, curDepth);
-      } else {
-        // track new paths
-        // (other than symlinks being followed, which will be tracked soon)
-        this.fsw._getWatchedDir(parent).add(item);
       }
+
+      // track new paths
+      // (other than symlinks being followed, which will be tracked soon)
+      this.fsw._getWatchedDir(parent).add(item);
     }
     /**
      * @type {'add'|'addDir'|'unlink'|'unlinkDir'}
@@ -466,7 +466,7 @@ async _addToFsEvents(path, transform, forceAdd, priorDepth) {
         if (entry.stats.isDirectory() && !wh.filterPath(entry)) return;
 
         const joinedPath = sysPath.join(wh.watchPath, entry.path);
-        const fullPath = entry.fullPath;
+        const {fullPath} = entry;
 
         if (wh.followSymlinks && entry.stats.isSymbolicLink()) {
           // preserve the current depth here since it can't be derived from

--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -2,8 +2,8 @@
 
 const fs = require('fs');
 const sysPath = require('path');
-const isBinaryPath = require('is-binary-path');
 const { promisify } = require('util');
+const isBinaryPath = require('is-binary-path');
 const {
   isWindows,
   EMPTY_FN,
@@ -186,7 +186,7 @@ const setFsWatchListener = (path, fullPath, options, handlers) => {
       listeners: listener,
       errHandlers: errHandler,
       rawEmitters: rawEmitter,
-      watcher: watcher
+      watcher
     };
     FsWatchInstances.set(fullPath, cont);
   }
@@ -227,8 +227,7 @@ const FsWatchFileInstances = new Map();
  * @returns {Function} closer
  */
 const setFsWatchFileListener = (path, fullPath, options, handlers) => {
-  const listener = handlers.listener;
-  const rawEmitter = handlers.rawEmitter;
+  const {listener, rawEmitter} = handlers;
   let cont = FsWatchFileInstances.get(fullPath);
   let listeners = new Set();
   let rawEmitters = new Set();
@@ -255,7 +254,7 @@ const setFsWatchFileListener = (path, fullPath, options, handlers) => {
     cont = {
       listeners: listener,
       rawEmitters: rawEmitter,
-      options: options,
+      options,
       watcher: fs.watchFile(fullPath, options, (curr, prev) => {
         foreach(cont.rawEmitters, (rawEmitter) => {
           rawEmitter(EV_CHANGE, fullPath, {curr, prev});
@@ -318,12 +317,12 @@ _watchWithNodeFs(path, listener) {
     options.interval = opts.enableBinaryInterval && isBinaryPath(basename) ?
       opts.binaryInterval : opts.interval;
     closer = setFsWatchFileListener(path, absolutePath, options, {
-      listener: listener,
+      listener,
       rawEmitter: this.fsw._emitRaw
     });
   } else {
     closer = setFsWatchListener(path, absolutePath, options, {
-      listener: listener,
+      listener,
       errHandler: this._boundHandleError,
       rawEmitter: this.fsw._emitRaw
     });
@@ -427,9 +426,9 @@ async _handleSymlink(entry, directory, path, item) {
   // don't follow the same symlink more than once
   if (this.fsw._symlinkPaths.has(full)) {
     return true;
-  } else {
-    this.fsw._symlinkPaths.set(full,  true);
   }
+
+  this.fsw._symlinkPaths.set(full, true);
 }
 
 _handleRead(directory, initialAdd, wh, target, dir, depth, throttler) {
@@ -447,7 +446,7 @@ _handleRead(directory, initialAdd, wh, target, dir, depth, throttler) {
   let stream = this.fsw._readdirp(directory, {
     fileFilter: entry => wh.filterPath(entry),
     directoryFilter: entry => wh.filterDir(entry),
-    depth: 0,
+    depth: 0
   }).on(STR_DATA, async (entry) => {
     if (this.fsw.closed) {
       stream = undefined;
@@ -534,8 +533,6 @@ async _handleDir(dir, stats, initialAdd, depth, target, wh, realpath) {
   parentDir.add(sysPath.basename(dir));
   this.fsw._getWatchedDir(dir);
   let throttler;
-
-
   let closer;
 
   const oDepth = this.fsw.options.depth;
@@ -572,7 +569,7 @@ async _addToNodeFs(path, initialAdd, priorWh, depth, target) {
     return false;
   }
 
-  let wh = this.fsw._getWatchHelpers(path, depth);
+  const wh = this.fsw._getWatchHelpers(path, depth);
   if (!wh.hasGlob && priorWh) {
     wh.hasGlob = priorWh.hasGlob;
     wh.globFilter = priorWh.globFilter;
@@ -589,7 +586,7 @@ async _addToNodeFs(path, initialAdd, priorWh, depth, target) {
       return false;
     }
 
-    const follow = this.fsw.options.followSymlinks && !path.includes("*") && !path.includes("{");
+    const follow = this.fsw.options.followSymlinks && !path.includes('*') && !path.includes('{');
     let closer;
     if (stats.isDirectory()) {
       const targetPath = follow ? await fsrealpath(path) : path;


### PR DESCRIPTION
* use `const` when possible
* use object destructuring consistently
* use object shorthand
* use the spread operator instead of `Array.from()` and `Object.assign()`
* use template literals
* use arrow functions when possible
* use the strict comparison operators
* remove unneeded else conditions
* remove unneeded escape characters
* remove unused variables

It would be nice if there was stricter linting. JSHint seems to be very much behind compared to ESLint, but this is a decision you should make @paulmillr.

That being said, I tried to not change your style, just tighten things a bit.

If there's something you don't like, let me know and I'll rebase this.