### PR TITLE
Make it clear that Node.js >= 8.10.0 is needed

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [8, 10, 12]
+        node-version: [8.10.0, 10, 12]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Elan Shanker"
   ],
   "engines": {
-    "node": ">= 8"
+    "node": ">=8.10.0"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Node.js 8.0.0 fails due to anymatch using the spread operator.