### PR TITLE
Update nyc options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-node_modules
-test-fixtures
 *.bak
 *.log
-.nyc_output
-package-lock.json
+/.nyc_output/
+/coverage/
+/node_modules/
+/test-fixtures/
+/package-lock.json

--- a/package.json
+++ b/package.json
@@ -77,5 +77,16 @@
     "predef": [
       "toString"
     ]
+  },
+  "nyc": {
+    "include": [
+      "index.js",
+      "lib/*.js"
+    ],
+    "reporter": [
+      "html",
+      "lcov",
+      "text"
+    ]
   }
 }


### PR DESCRIPTION
* be explicit with the files we want included
* add more reporters

@paulmillr note that this does output files in a local coverage folder. But this way one case see the HTML report locally, which is nice since there is no coverage service integrated with the repo. We could add code-cov or whatever service you want later.