### PR TITLE
Add Coveralls support.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,3 +22,9 @@ jobs:
       - run: npm install
       - name: Run tests
         run: npm test
+
+      - name: Run Coveralls
+        uses: coverallsapp/github-action@master
+        if: startsWith(matrix.os, 'ubuntu') && matrix.node == 10
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "devDependencies": {
     "@types/node": "^12",
     "chai": "^4.2",
-    "coveralls": "^3",
     "dtslint": "0.4.1",
     "jshint": "^2.10.2",
     "mocha": "^6.2.1",
@@ -51,11 +50,10 @@
   },
   "license": "MIT",
   "scripts": {
-    "test": "nyc mocha --exit",
-    "mocha": "mocha",
+    "dtslint": "dtslint types",
     "lint": "jshint index.js lib",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls",
-    "dtslint": "dtslint types"
+    "mocha": "mocha",
+    "test": "nyc mocha --exit"
   },
   "keywords": [
     "fs",


### PR DESCRIPTION
Only runs for Node.js 10 and on Ubuntu.

Just testing this, we can use whatever service you like.

The coveralls action has one downside: you will get a comment in PRs even if you have them disabled.

Anyway, let me know if you want this. If you do, please add the repo in the service of your choice and I will adapt this patch.