### PR TITLE
Remove redundant assignment of `closers` in `_closePath()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -872,11 +872,10 @@ _remove(directory, item) {
  * @param {Path} path
  */
 _closePath(path) {
-  let closers = this._closers.get(path);
+  const closers = this._closers.get(path);
   if (!closers) return;
   closers.forEach(closer => closer());
   this._closers.delete(path);
-  closers = [];
   const dir = sysPath.dirname(path);
   this._getWatchedDir(dir).remove(sysPath.basename(path));
 }


### PR DESCRIPTION
@paulmillr please confirm but this seems redundant.

Spotted on https://lgtm.com/projects/g/paulmillr/chokidar/snapshot/6566af3810bbd3d997981492bb790b998d8bbacb/files/index.js?sort=name&dir=ASC&mode=heatmap#xa3247f4a490bc9a1:1