### PR TITLE
nodefs-handler.js: fix variable always evaluating to true.

### DIFF
--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -357,7 +357,7 @@ _handleFile(file, stats, initialAdd) {
   // kick off the watcher
   const closer = this._watchWithNodeFs(file, async (path, newStats) => {
     if (!this.fsw._throttle(THROTTLE_MODE_WATCH, file, 5)) return;
-    if (!newStats || newStats && newStats.mtimeMs === 0) {
+    if (!newStats || newStats.mtimeMs === 0) {
       try {
         const newStats = await stat(file);
         if (this.fsw.closed) return;


### PR DESCRIPTION
Spotted on https://lgtm.com/projects/g/paulmillr/chokidar/snapshot/6566af3810bbd3d997981492bb790b998d8bbacb/files/lib/nodefs-handler.js?sort=name&dir=ASC&mode=heatmap#x9c36faebb50360e4:1

BTW lgtm.com is now owned by GitHub so you could enable code reviews @paulmillr. Just make sure you disable PR commenting