### PR TITLE
Handle replacement with other type with fsevents

### DIFF
--- a/index.js
+++ b/index.js
@@ -822,13 +822,15 @@ _hasReadPermissions(stats) {
  * @param {String} item      base path of item/directory
  * @returns {void}
 */
-_remove(directory, item) {
+_remove(directory, item, isDirectory) {
   // if what is being deleted is a directory, get that directory's paths
   // for recursive deleting and cleaning of watched object
   // if it is not a directory, nestedDirectoryChildren will be empty array
   const path = sysPath.join(directory, item);
   const fullPath = sysPath.resolve(path);
-  const isDirectory = this._watched.has(path) || this._watched.has(fullPath);
+  isDirectory = isDirectory != null
+    ? isDirectory
+    : this._watched.has(path) || this._watched.has(fullPath);
 
   // prevent duplicate handling in case of arriving here nearly simultaneously
   // via multiple paths (such as _handleFile and _handleDir)

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -23,6 +23,7 @@ exports.FSEVENT_DELETED = 'deleted';
 exports.FSEVENT_MOVED = 'moved';
 exports.FSEVENT_CLONED = 'cloned';
 exports.FSEVENT_UNKNOWN = 'unknown';
+exports.FSEVENT_TYPE_FILE = 'file';
 exports.FSEVENT_TYPE_DIRECTORY = 'directory';
 exports.FSEVENT_TYPE_SYMLINK = 'symlink';
 

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -37,6 +37,7 @@ const {
   FSEVENT_MOVED,
   // FSEVENT_CLONED,
   FSEVENT_UNKNOWN,
+  FSEVENT_TYPE_FILE,
   FSEVENT_TYPE_DIRECTORY,
   FSEVENT_TYPE_SYMLINK,
 
@@ -47,13 +48,10 @@ const {
   EMPTY_FN,
   IDENTITY_FN
 } = require('./constants');
-const FS_MODE_READ = 'r';
 
 const Depth = (value) => isNaN(value) ? {} : {depth: value};
 
 const stat = promisify(fs.stat);
-const open = promisify(fs.open);
-const close = promisify(fs.close);
 const lstat = promisify(fs.lstat);
 const realpath = promisify(fs.realpath);
 
@@ -202,6 +200,14 @@ const calcDepth = (path, root) => {
   return i;
 };
 
+// returns boolean indicating whether the fsevents' event info has the same type
+// as the one returned by fs.stat
+const sameTypes = (info, stats) => (
+  info.type === FSEVENT_TYPE_DIRECTORY && stats.isDirectory() ||
+  info.type === FSEVENT_TYPE_SYMLINK && stats.isSymbolicLink() ||
+  info.type === FSEVENT_TYPE_FILE && stats.isFile()
+)
+
 /**
  * @mixin
  */
@@ -232,13 +238,16 @@ addOrChange(path, fullPath, realPath, parent, watchedDir, item, info, opts) {
   this.handleEvent(event, path, fullPath, realPath, parent, watchedDir, item, info, opts);
 }
 
-async checkFd(path, fullPath, realPath, parent, watchedDir, item, info, opts) {
+async checkExists(path, fullPath, realPath, parent, watchedDir, item, info, opts) {
   try {
-    const fd = await open(path, FS_MODE_READ);
+    const stats = await stat(path)
     if (this.fsw.closed) return;
-    await close(fd);
     if (this.fsw.closed) return;
-    this.addOrChange(path, fullPath, realPath, parent, watchedDir, item, info, opts);
+    if (sameTypes(info, stats)) {
+      this.addOrChange(path, fullPath, realPath, parent, watchedDir, item, info, opts);
+    } else {
+      this.handleEvent(EV_UNLINK, path, fullPath, realPath, parent, watchedDir, item, info, opts);
+    }
   } catch (error) {
     if (error.code === 'EACCES') {
       this.addOrChange(path, fullPath, realPath, parent, watchedDir, item, info, opts);
@@ -252,9 +261,10 @@ handleEvent(event, path, fullPath, realPath, parent, watchedDir, item, info, opt
   if (this.fsw.closed || this.checkIgnored(path)) return;
 
   if (event === EV_UNLINK) {
+    const isDirectory = info.type === FSEVENT_TYPE_DIRECTORY
     // suppress unlink events on never before seen files
-    if (info.type === FSEVENT_TYPE_DIRECTORY || watchedDir.has(item)) {
-      this.fsw._remove(parent, item);
+    if (isDirectory || watchedDir.has(item)) {
+      this.fsw._remove(parent, item, isDirectory);
     }
   } else {
     if (event === EV_ADD) {
@@ -319,13 +329,13 @@ _watchWithFsEvents(watchPath, realPath, transform, globFilter) {
         } catch (error) {}
         if (this.fsw.closed) return;
         if (this.checkIgnored(path, stats)) return;
-        if (stats) {
+        if (sameTypes(info, stats)) {
           this.addOrChange(path, fullPath, realPath, parent, watchedDir, item, info, opts);
         } else {
           this.handleEvent(EV_UNLINK, path, fullPath, realPath, parent, watchedDir, item, info, opts);
         }
       } else {
-        this.checkFd(path, fullPath, realPath, parent, watchedDir, item, info, opts);
+        this.checkExists(path, fullPath, realPath, parent, watchedDir, item, info, opts);
       }
     } else {
       switch (info.event) {
@@ -334,7 +344,7 @@ _watchWithFsEvents(watchPath, realPath, transform, globFilter) {
         return this.addOrChange(path, fullPath, realPath, parent, watchedDir, item, info, opts);
       case FSEVENT_DELETED:
       case FSEVENT_MOVED:
-        return this.checkFd(path, fullPath, realPath, parent, watchedDir, item, info, opts);
+        return this.checkExists(path, fullPath, realPath, parent, watchedDir, item, info, opts);
       }
     }
   };


### PR DESCRIPTION
Fixes #996

When using `fsevents` on macOS, if a directory is replaced by a file,
an `addDir` event is emitted instead of an `unlinkDir` event followed
by a `change` event instead of an `add` event.
If a directory is replaced by a file, a `change` event is emitted
instead of an `unlink` event is emitted, followed by a correct `addDir`
event.

This issue comes from the way we detect the existence of a file or
directory when handling an event with wrong flags or no type.
We check the document's existence with a call to `fs.open` and expect
it to error out if the document does not exist anymore. But, in case
the document was replaced before we got to handle its removal, we will
be able to open its replacement and will then emit an add or change
event.

The proposed solution here is to compare the type given by a call to
`fs.stat` and the type returned by fsevents. If they're equal, we'll
assume we're dealing with an addition or a change. If they're
different, we'll assume we're dealing with a replacement and thus emit
an unlink event.