### PR TITLE
add `safe-edit` handling for Linux, fixes #591

### DIFF
--- a/index.js
+++ b/index.js
@@ -876,16 +876,24 @@ _remove(directory, item, isDirectory) {
 }
 
 /**
- *
+ * Closes all watchers for a path
  * @param {Path} path
  */
 _closePath(path) {
+  this._closeFile(path)
+  const dir = sysPath.dirname(path);
+  this._getWatchedDir(dir).remove(sysPath.basename(path));
+}
+
+/**
+ * Closes only file-specific watchers
+ * @param {Path} path
+ */
+_closeFile(path) {
   const closers = this._closers.get(path);
   if (!closers) return;
   closers.forEach(closer => closer());
   this._closers.delete(path);
-  const dir = sysPath.dirname(path);
-  this._getWatchedDir(dir).remove(sysPath.basename(path));
 }
 
 /**

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -59,3 +59,4 @@ exports.IDENTITY_FN = val => val;
 
 exports.isWindows = platform === 'win32';
 exports.isMacos = platform === 'darwin';
+exports.isLinux = platform === 'linux';

--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -6,6 +6,7 @@ const { promisify } = require('util');
 const isBinaryPath = require('is-binary-path');
 const {
   isWindows,
+  isLinux,
   EMPTY_FN,
   EMPTY_STR,
   KEY_LISTENERS,
@@ -356,8 +357,7 @@ _handleFile(file, stats, initialAdd) {
   // if the file is already being watched, do nothing
   if (parent.has(basename)) return;
 
-  // kick off the watcher
-  const closer = this._watchWithNodeFs(file, async (path, newStats) => {
+  const listener = async (path, newStats) => {
     if (!this.fsw._throttle(THROTTLE_MODE_WATCH, file, 5)) return;
     if (!newStats || newStats.mtimeMs === 0) {
       try {
@@ -369,12 +369,18 @@ _handleFile(file, stats, initialAdd) {
         if (!at || at <= mt || mt !== prevStats.mtimeMs) {
           this.fsw._emit(EV_CHANGE, file, newStats);
         }
-        prevStats = newStats;
+        if (isLinux && prevStats.ino !== newStats.ino) {
+          this.fsw._closeFile(path)
+          prevStats = newStats;
+          this.fsw._addPathCloser(path, this._watchWithNodeFs(file, listener));
+        } else {
+          prevStats = newStats;
+        }
       } catch (error) {
         // Fix issues where mtime is null but file is still present
         this.fsw._remove(dirname, basename);
       }
-    // add is about to be emitted if file not already tracked in parent
+      // add is about to be emitted if file not already tracked in parent
     } else if (parent.has(basename)) {
       // Check that change event was not fired because of changed only accessTime.
       const at = newStats.atimeMs;
@@ -384,7 +390,9 @@ _handleFile(file, stats, initialAdd) {
       }
       prevStats = newStats;
     }
-  });
+  }
+  // kick off the watcher
+  const closer = this._watchWithNodeFs(file, listener);
 
   // emit an add event if we're supposed to
   if (!(initialAdd && this.fsw.options.ignoreInitial) && this.fsw._isntIgnored(file)) {


### PR DESCRIPTION
will re-add the watcher on inode change in `fs.watch` mode on Linux

bonus: fixed strange, pretty infrequent race in `fs.watchFile` test case `should emit matching dir events`