### PR TITLE
Ensure closing watchers does not affect other watchers

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -103,7 +103,7 @@ const createFSEventsInstance = (path, callback) => {
  * @param {Function} rawEmitter - passes data to listeners of the 'raw' event
  * @returns {Function} closer
  */
-function setFSEventsListener(path, realPath, listener, rawEmitter, fsw) {
+function setFSEventsListener(path, realPath, listener, rawEmitter) {
   let watchPath = sysPath.extname(path) ? sysPath.dirname(path) : path;
   const parentPath = sysPath.dirname(watchPath);
   let cont = FSEventsWatchers.get(watchPath);
@@ -353,8 +353,7 @@ _watchWithFsEvents(watchPath, realPath, transform, globFilter) {
     watchPath,
     realPath,
     watchCallback,
-    this.fsw._emitRaw,
-    this.fsw
+    this.fsw._emitRaw
   );
 
   this.fsw._emitReady();

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -146,7 +146,7 @@ function setFSEventsListener(path, realPath, listener, rawEmitter, fsw) {
       listeners: new Set([filteredListener]),
       rawEmitter,
       watcher: createFSEventsInstance(watchPath, (fullPath, flags) => {
-        if (fsw.closed) return;
+        if (!cont.listeners.size) return;
         const info = fsevents.getInfo(fullPath, flags);
         cont.listeners.forEach(list => {
           list(fullPath, flags, info);


### PR DESCRIPTION
If the first watcher that was created gets closed all other watchers will no longer receive events.

Ran into this scenario after we upgraded Next.js to use the latest chokidar that came with the latest stable watchpack. With chokidar v2 (which watchpack previously depended on) this test passes fine. Using v3 it stops reporting filesystem events.

So far I've tracked it down to this particular line:
https://github.com/paulmillr/chokidar/blob/master/lib/fsevents-handler.js#L149

Because the part that creates the context is only called on the first watcher the `fsw` variable will 
always refer to that first watcher. 

- The code in particular loops over the listeners on [`const.listeners`](https://github.com/paulmillr/chokidar/blob/master/lib/fsevents-handler.js#L151)
  - It doesn't need to know if the watcher itself is closed, only if there's listeners left
  - The listeners are correctly [removed when a watcher is closed](https://github.com/paulmillr/chokidar/blob/master/lib/fsevents-handler.js#L166)
  - The watcher itself is thrown away correctly when [the last listener of that path is deleted](https://github.com/paulmillr/chokidar/blob/master/lib/fsevents-handler.js#L168-L172)
  - Given the above it seems that the best solutions to solve this issue is checking `cont.listeners.size` instead of `fsw.closed`
  - Considering the watcher is cleaned up correctly on close the check might not be necessary, though it probably handles an edge case of in-between closing the watcher.

The symptoms (only on macOS) would be that webpack did not recompile after introducing an error or after doing a bunch of quick changes to a certain file. With the change in this PR applied the symptoms are no longer there.

The particular reason this surfaces in webpack is that when an error happens the watchers are closed and recreated when a compilation error happens as files/dependencies could have changed in between.