### PR TITLE
handle network path `//server` correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ const {
   REPLACER_RE,
 
   SLASH,
+  SLASH_SLASH,
   BRACE_START,
   BANG,
   ONE_DOT,
@@ -96,10 +97,19 @@ const unifyPaths = (paths_) => {
   return paths.map(normalizePathToUnix);
 };
 
+// If SLASH_SLASH occurs at the beginning of path, it is not replaced
+//     because "//StoragePC/DrivePool/Movies" is a valid network path
 const toUnix = (string) => {
   let str = string.replace(BACK_SLASH_RE, SLASH);
+  let prepend = false;
+  if (str.startsWith(SLASH_SLASH)) {
+    prepend = true;
+  }
   while (str.match(DOUBLE_SLASH_RE)) {
     str = str.replace(DOUBLE_SLASH_RE, SLASH);
+  }
+  if (prepend) {
+    str = SLASH + str;
   }
   return str;
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -41,6 +41,7 @@ exports.DOT_RE = /\..*\.(sw[px])$|~$|\.subl.*\.tmp/;
 exports.REPLACER_RE = /^\.[/\\]/;
 
 exports.SLASH = '/';
+exports.SLASH_SLASH = '//';
 exports.BRACE_START = '{';
 exports.BANG = '!';
 exports.ONE_DOT = '.';

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -242,7 +242,6 @@ async checkExists(path, fullPath, realPath, parent, watchedDir, item, info, opts
   try {
     const stats = await stat(path)
     if (this.fsw.closed) return;
-    if (this.fsw.closed) return;
     if (sameTypes(info, stats)) {
       this.addOrChange(path, fullPath, realPath, parent, watchedDir, item, info, opts);
     } else {


### PR DESCRIPTION
In current `master` branch, `chokidar` fails to recognize paths starting with `//` or `\\` for example:

`//StoragePC/DrivePool/movies` is a valid network path, but `toUnix` method would replace `//` with `/` making the path invalid.

More details: https://github.com/paulmillr/chokidar/issues/895#issuecomment-660518084

Closes #895 

Tested with my app. PR successfully resolves the problem: https://github.com/whyboris/Video-Hub-App/issues/456#issuecomment-664038303

Unit test results unchanged from `master`:
```
  192 passing (1m)
  12 pending
  1 failing     <-- should emit `unlinkDir` and `add` when dir is replaced by file:
```

please let me know if you prefer the constant name to be `DOUBLE_SLASH` instead of `SLASH_SLASH` 👍 