### PR TITLE
Merge bugfix/#1042 into paulmillr/chokidar:master

### DIFF
--- a/index.js
+++ b/index.js
@@ -864,6 +864,15 @@ _remove(directory, item, isDirectory) {
   const wasTracked = parent.has(item);
   parent.remove(item);
 
+  // Fixes issue #1042 -> Relative paths were detected and added as symlinks
+  // (https://github.com/paulmillr/chokidar/blob/e1753ddbc9571bdc33b4a4af172d52cb6e611c10/lib/nodefs-handler.js#L612),
+  // but never removed from the map in case the path was deleted.
+  // This leads to an incorrect state if the path was recreated:
+  // https://github.com/paulmillr/chokidar/blob/e1753ddbc9571bdc33b4a4af172d52cb6e611c10/lib/nodefs-handler.js#L553
+  if (this._symlinkPaths.has(fullPath)) {
+    this._symlinkPaths.delete(fullPath);
+  }
+
   // If we wait for this file to be fully written, cancel the wait.
   let relPath = path;
   if (this.options.cwd) relPath = sysPath.relative(this.options.cwd, path);

--- a/test.js
+++ b/test.js
@@ -2102,6 +2102,46 @@ const runTests = (baseopts) => {
       });
     }
   });
+  describe('reproduction of bug in issue #1024', () => {
+    it('should detect changes to folders, even if they were deleted before', async () => {
+      const id = subdirId.toString();
+      const relativeWatcherDir = sysPath.join(FIXTURES_PATH_REL, id, 'test');
+      const watcher = chokidar.watch(relativeWatcherDir, {
+        persistent: true,
+      });
+      try {
+        const events = [];
+        watcher.on('all', (event, path) =>
+          events.push(`[ALL] ${event}: ${path}`)
+        );
+        const testSubDir = sysPath.join(relativeWatcherDir, 'dir');
+        const testSubDirFile = sysPath.join(relativeWatcherDir, 'dir', 'file');
+
+        // Command sequence from https://github.com/paulmillr/chokidar/issues/1042.
+        await delay();
+        await fs_mkdir(relativeWatcherDir);
+        await fs_mkdir(testSubDir);
+        // The following delay is essential otherwise the call of mkdir and rmdir will be equalize
+        await delay(300);
+        await fs_rmdir(testSubDir);
+        // The following delay is essential otherwise the call of rmdir and mkdir will be equalize
+        await delay(300);
+        await fs_mkdir(testSubDir);
+        await write(testSubDirFile, '');
+        await delay(300);
+        
+        chai.assert.deepStrictEqual(events, [
+          `[ALL] addDir: test-fixtures/${id}/test`,
+          `[ALL] addDir: test-fixtures/${id}/test/dir`,
+          `[ALL] unlinkDir: test-fixtures/${id}/test/dir`,
+          `[ALL] addDir: test-fixtures/${id}/test/dir`,
+          `[ALL] add: test-fixtures/${id}/test/dir/file`,
+        ]);
+      } finally {
+        watcher.close();
+      }
+    });
+  });
 };
 
 describe('chokidar', () => {

--- a/test.js
+++ b/test.js
@@ -2131,11 +2131,11 @@ const runTests = (baseopts) => {
         await delay(300);
         
         chai.assert.deepStrictEqual(events, [
-          `[ALL] addDir: test-fixtures/${id}/test`,
-          `[ALL] addDir: test-fixtures/${id}/test/dir`,
-          `[ALL] unlinkDir: test-fixtures/${id}/test/dir`,
-          `[ALL] addDir: test-fixtures/${id}/test/dir`,
-          `[ALL] add: test-fixtures/${id}/test/dir/file`,
+          `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test')}`,
+          `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test', 'dir')}`,
+          `[ALL] unlinkDir: ${sysPath.join('test-fixtures', id, 'test', 'dir')}`,
+          `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test', 'dir')}`,
+          `[ALL] add: ${sysPath.join('test-fixtures', id, 'test', 'dir', 'file')}`,
         ]);
       } finally {
         watcher.close();


### PR DESCRIPTION
After some investigation, I was able to reproduce and fix the bug!

**Problem:**

If a relative path was passed when calling chokidar.watch, it was [processed internally as a symlink](https://github.com/paulmillr/chokidar/blob/e1753ddbc9571bdc33b4a4af172d52cb6e611c10/lib/nodefs-handler.js#L612).

Unfortunately, there was a bug in the handling of symlinks, which were never removed from the internal collection when the target path was deleted. [This then resulted in an incorrect state when the path was recreated](https://github.com/paulmillr/chokidar/blob/e1753ddbc9571bdc33b4a4af172d52cb6e611c10/lib/nodefs-handler.js#L553).

**Workaround for the current version:**

Only use absolute paths as watch directory and avoid watching folders with symlinks.

**Solution:**

There are several possible solutions to fix the error. In my merge request, I decided to take the most obvious and minimally invasive approach. I simply added a line of code to remove the symlinks from the collection if the target path was removed.

However, at first glance I don't see any reason why a relative path has to be recognized as a symlink.
On the other hand, my approach then solves both the bug #1042 and the problem that symlinks were not cleaned up.

**Risk and Recommendation:**

Unfortunately, I had to realize that the bug has a larger scope than I had assumed.
Since the symlinks are never cleaned up, the longer the Watcher instance is active, the more often this bug occurs.
For this reason I recommend to merge my bugfix into the official repository as soon as possible, or to solve the bug in another way.