### PR TITLE
Bugfix/#1061

### DIFF
--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -603,13 +603,14 @@ async _addToNodeFs(path, initialAdd, priorWh, depth, target) {
     const follow = this.fsw.options.followSymlinks && !path.includes(STAR) && !path.includes(BRACE_START);
     let closer;
     if (stats.isDirectory()) {
+      const absPath = sysPath.resolve(path);
       const targetPath = follow ? await fsrealpath(path) : path;
       if (this.fsw.closed) return;
       closer = await this._handleDir(wh.watchPath, stats, initialAdd, depth, target, wh, targetPath);
       if (this.fsw.closed) return;
       // preserve this symlink's target path
-      if (path !== targetPath && targetPath !== undefined) {
-        this.fsw._symlinkPaths.set(targetPath, true);
+      if (absPath !== targetPath && targetPath !== undefined) {
+        this.fsw._symlinkPaths.set(absPath, targetPath);
       }
     } else if (stats.isSymbolicLink()) {
       const targetPath = follow ? await fsrealpath(path) : path;


### PR DESCRIPTION
**Problem:**

The basic bug was the same as already fixed in Issue #1042.
However, the bugfix solved the problem only for relative paths, but not for symlink paths (part of the path is a symlink).

The reason for this was the **incorrect** assumption that:
`fs.realpath(path) != path ==> path is a symlink path`

**Correct assumption**:
`fs.realpath(path) != path ==> path is a symlink path or a relative`


**Solution:**
`fs.realpath(path) != fs.resolve(path) ==> path is a symlink path`

Also, it was a bug to remember the resolved path instead of link-path, because with this is used internally.

