### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "anymatch": "~3.1.1",
     "braces": "~3.0.2",
-    "glob-parent": "~5.1.0",
+    "glob-parent": "~3.0.0",
     "is-binary-path": "~2.1.0",
     "is-glob": "~4.0.1",
     "normalize-path": "~3.0.0",


### PR DESCRIPTION
glob-parent was flagged as of this morning with high severity security risk. The recommendation is to downgrade to 3.0.0, 2.0.0, or 1.0.0.