### PR TITLE
Limit node version to <= 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "lib/",
     "types/index.d.ts"
   ],
+  "engines": {
+    "node": "<=12"
+  },
   "dependencies": {
     "anymatch": "^2.0.0",
     "async-each": "^1.0.1",


### PR DESCRIPTION
This PR adds a limitation on node versions. It should ensure `chokidar@2.x` doesn't get accidentally installed in unsupported Node versions.

[Reference](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines)