### PR TITLE
fix some tests by adding delay and moving some tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "dtslint": "dtslint types",
     "lint": "eslint --report-unused-disable-directives --ignore-path .gitignore .",
-    "mocha": "mocha --exit --timeout 60000",
+    "mocha": "mocha --exit --timeout 90000",
     "test": "npm run lint && npm run mocha"
   },
   "keywords": [


### PR DESCRIPTION
hi @paulmillr,

By adding some delays and moving some tests, it is a little better.

My tests are ok but some continue to failed.
The failed are not link to my fix. Some failed seems to be random...

The #1024 continue to failed on my mac with or without my changes, but with my changes it is a little better.

The "close" test involve lot of errors but if it move to the end of the file, it is ok...


Can you test this fix on your mac?