### PR TITLE
Fix doc for unwatch() and close().

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ Available events: `add`, `addDir`, `change`, `unlink`, `unlinkDir`, `ready`,
 Additionally `all` is available which gets emitted with the underlying event
 name and path for every event other than `ready`, `raw`, and `error`.  `raw` is internal, use it carefully.
 * `.unwatch(path / paths)`: Stop watching files, directories, or glob patterns.
-Takes an array of strings or just one string. Use with `await` to ensure bugs don't happen.
-* `.close()`: **async** Removes all listeners from watched files. Asynchronous, returns Promise.
+Takes an array of strings or just one string.
+* `.close()`: **async** Removes all listeners from watched files. Asynchronous, returns Promise. Use with `await` to ensure bugs don't happen.
 * `.getWatched()`: Returns an object representing all the paths on the file
 system being watched by this `FSWatcher` instance. The object's keys are all the
 directories (using absolute paths unless the `cwd` option was used), and the


### PR DESCRIPTION
`.unwatch()` does not return a promise. `.close()` does.

https://github.com/paulmillr/chokidar/blob/820ab96d3ee4687b53f839410bef20d2123e08ef/index.js#L494-L496

https://github.com/paulmillr/chokidar/blob/820ab96d3ee4687b53f839410bef20d2123e08ef/index.js#L521-L524

