### PR TITLE
types: use correct type def for ignored option

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,7 @@
 
 import * as fs from "fs";
 import { EventEmitter } from "events";
+import { Matcher } from 'anymatch'
 
 export class FSWatcher extends EventEmitter implements fs.FSWatcher {
   options: WatchOptions;
@@ -79,7 +80,7 @@ export interface WatchOptions {
    * (the path), second time with two arguments (the path and the
    * [`fs.Stats`](https://nodejs.org/api/fs.html#fs_class_fs_stats) object of that path).
    */
-  ignored?: any;
+  ignored?: Matcher;
 
   /**
    * If set to `false` then `add`/`addDir` events are also emitted for matching paths while


### PR DESCRIPTION
I'm trying to make vite type dev more accurate (vitejs/vite#4616) and found the type def is from upstream which is chokidar.