### PR TITLE
fix: improve `add` and `unwatch` TypeScript definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,13 +18,13 @@ export class FSWatcher extends EventEmitter implements fs.FSWatcher {
    * Add files, directories, or glob patterns for tracking. Takes an array of strings or just one
    * string.
    */
-  add(paths: string | ReadonlyArray<string>): void;
+  add(paths: string | ReadonlyArray<string>): this;
 
   /**
    * Stop watching files, directories, or glob patterns. Takes an array of strings or just one
    * string.
    */
-  unwatch(paths: string | ReadonlyArray<string>): void;
+  unwatch(paths: string | ReadonlyArray<string>): this;
 
   /**
    * Returns an object representing all the paths on the file system being watched by this

--- a/types/test.ts
+++ b/types/test.ts
@@ -9,6 +9,8 @@ const watcher = chokidar.watch("file, dir, or glob", {
 const log = console.log.bind(console);
 
 watcher
+  .add('./foo.js')
+  .unwatch('./bar.js')
   .on("add", (path: string) => {
     log("File", path, "has been added");
   })


### PR DESCRIPTION
The return type of these methods should be `this` to support chaining.