### PR TITLE
fix: Upgrading Vulnerable glob-parent package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "anymatch": "~3.1.2",
     "braces": "~3.0.2",
-    "glob-parent": "~5.1.2",
+    "glob-parent": "~6.0.2",
     "is-binary-path": "~2.1.0",
     "is-glob": "~4.0.1",
     "normalize-path": "~3.0.0",


### PR DESCRIPTION
Updating glob-parent version from 5.1.2 to 6.0.2 since the previous version has a severe security vulnerability.

CVE-2020-28469
