### PR TITLE
Replace braces dependency with brace-expansion

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const readdirp = require('readdirp');
 const anymatch = require('anymatch').default;
 const globParent = require('glob-parent');
 const isGlob = require('is-glob');
-const braces = require('braces');
+const expand = require('brace-expansion');
 const normalizePath = require('normalize-path');
 
 const NodeFsHandler = require('./lib/nodefs-handler');
@@ -255,7 +255,7 @@ class WatchHelper {
   getDirParts(path) {
     if (!this.hasGlob) return [];
     const parts = [];
-    const expandedPath = path.includes(BRACE_START) ? braces.expand(path) : [path];
+    const expandedPath = path.includes(BRACE_START) ? expand(path) : [path];
     expandedPath.forEach((path) => {
       parts.push(sysPath.relative(this.watchPath, path).split(SLASH_OR_BACK_SLASH_RE));
     });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "index.js",
   "dependencies": {
     "anymatch": "~3.1.2",
-    "braces": "~3.0.2",
+    "brace-expansion": "^1.1.11",
     "glob-parent": "~5.1.2",
     "is-binary-path": "~2.1.0",
     "is-glob": "~4.0.1",


### PR DESCRIPTION
### Why?

1. This project uses braces for the sole purpose of glob pattern expansion. Braces is overly complex for the use case.
1. Braces is obsolete -- last updated 3 years ago
1. The braces package depends on the ridiculous is-number package

My PR suggests replacing braces with brace-expansion.  
It is similar in popularity (156 github stars vs 150 for braces, 26M downloads vs 48M for braces), there is some commit activity so it is maintained, it has exactly 1 dependency.