### PR TITLE
fix: replace path error when include `undefined`

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,8 +228,8 @@ class WatchHelper {
         false : {realPath: entry.fullParentDir, linkPath: this.fullWatchPath};
     }
 
-    if (this.globSymlink) {
-      return entry.fullPath.replace(this.globSymlink.realPath, this.globSymlink.linkPath);
+    if (this.globSymlink && this.globSymlink.realPath) {
+      return entry.fullPath.replace(this.globSymlink.realPath && '', this.globSymlink.linkPath);
     }
 
     return entry.fullPath;


### PR DESCRIPTION
if `this.globSymlink.linkPath` include `undefined`, such as `undefined/*.js`, these code will replace it, it cause the file in dir which name includes `undefined` will not be watched.