### PR TITLE
handle MustScanSubDirs

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -24,6 +24,7 @@ exports.FSEVENT_DELETED = 'deleted';
 exports.FSEVENT_MOVED = 'moved';
 exports.FSEVENT_CLONED = 'cloned';
 exports.FSEVENT_UNKNOWN = 'unknown';
+exports.FSEVENT_FLAG_MUST_SCAN_SUBDIRS = 1;
 exports.FSEVENT_TYPE_FILE = 'file';
 exports.FSEVENT_TYPE_DIRECTORY = 'directory';
 exports.FSEVENT_TYPE_SYMLINK = 'symlink';

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -37,6 +37,7 @@ const {
   FSEVENT_MOVED,
   // FSEVENT_CLONED,
   FSEVENT_UNKNOWN,
+  FSEVENT_FLAG_MUST_SCAN_SUBDIRS,
   FSEVENT_TYPE_FILE,
   FSEVENT_TYPE_DIRECTORY,
   FSEVENT_TYPE_SYMLINK,
@@ -48,9 +49,6 @@ const {
   EMPTY_FN,
   IDENTITY_FN
 } = require('./constants');
-
-// See kFSEventStreamEventFlagMustScanSubDirs in FSEvents documentation
-const MUST_SCAN_SUBDIRS_FLAG = 1;
 
 const Depth = (value) => isNaN(value) ? {} : {depth: value};
 
@@ -151,7 +149,7 @@ function setFSEventsListener(path, realPath, listener, rawEmitter) {
       rawEmitter,
       watcher: createFSEventsInstance(watchPath, (fullPath, flags) => {
         if (!cont.listeners.size) return;
-        if (flags & MUST_SCAN_SUBDIRS_FLAG) return;
+        if (flags & FSEVENT_FLAG_MUST_SCAN_SUBDIRS) return;
         const info = fsevents.getInfo(fullPath, flags);
         cont.listeners.forEach(list => {
           list(fullPath, flags, info);

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -49,6 +49,9 @@ const {
   IDENTITY_FN
 } = require('./constants');
 
+// See kFSEventStreamEventFlagMustScanSubDirs in FSEvents documentation
+const MUST_SCAN_SUBDIRS_FLAG = 1;
+
 const Depth = (value) => isNaN(value) ? {} : {depth: value};
 
 const stat = promisify(fs.stat);
@@ -148,6 +151,7 @@ function setFSEventsListener(path, realPath, listener, rawEmitter) {
       rawEmitter,
       watcher: createFSEventsInstance(watchPath, (fullPath, flags) => {
         if (!cont.listeners.size) return;
+        if (flags & MUST_SCAN_SUBDIRS_FLAG) return;
         const info = fsevents.getInfo(fullPath, flags);
         cont.listeners.forEach(list => {
           list(fullPath, flags, info);


### PR DESCRIPTION
If the system is flooded with too many fsevents (for example, you are watching a directory that undergoes a huge number of changes all at once, and the user code to process these events is slow), a buffer of events can fill up and trigger a kFSEventStreamEventFlagMustScanSubDirs event.

See the [following documentation](https://developer.apple.com/documentation/coreservices/1455361-fseventstreameventflags/kfseventstreameventflagmustscansubdirs):

> The kFSEventStreamEventFlagUserDropped or kFSEventStreamEventFlagKernelDropped flags may be set in addition to the kFSEventStreamEventFlagMustScanSubDirs flag to indicate that a problem occurred in buffering the events (the particular flag set indicates where the problem occurred) and that the client must do a full scan of any directories (and their subdirectories, recursively) being monitored by this stream. If you asked to monitor multiple paths with this stream then you will be notified about all of them. Your code need only check for the kFSEventStreamEventFlagMustScanSubDirs flag; these flags (if present) only provide information to help you diagnose the problem.

When this happens, fsevents.info() returns an undefined `type`, which chokidar incorrectly interprets as an unlink. This PR explicitly checks for kFSEventStreamEventFlagMustScanSubDirs before calling fsevents.info and ignores events of this type.

Relevant: fsevents/fsevents#372

Fixes #1196