### PR TITLE
Fix for a race condition on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,6 +136,8 @@ const getAbsolutePath = (path, cwd) => {
 
 const undef = (opts, key) => opts[key] === undefined;
 
+const NODE_MAJOR_VERSION = Number(process.versions.node.split('.')[0]);
+
 /**
  * Directory entry.
  * @property {Path} path
@@ -950,6 +952,17 @@ _readdirp(root, opts) {
       stream = undefined;
     }
   });
+
+  if (NODE_MAJOR_VERSION < 10) {
+    // On Node 8 Readable.push() throws when the stream is destroyed
+    // even though the documentation says it should be silently ignored.
+    const superPush = stream.push.bind(stream);
+    stream.push = function (...args) {
+      if (this.destroyed) return false;
+      return superPush(...args);
+    }
+  }
+
   return stream;
 }
 

--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -570,6 +570,11 @@ async _handleDir(dir, stats, initialAdd, depth, target, wh, realpath) {
 
       this._handleRead(dirPath, false, wh, target, dir, depth, throttler);
     });
+
+    // schedule a rescan of the directory in case something
+    // appeared while we were setting up the watch
+    if (!(this.fsw.usePolling || target || this.fsw.closed))
+      this._handleRead(dir, false, wh, target, dir, depth, throttler);
   }
   return closer;
 }

--- a/test.js
+++ b/test.js
@@ -2192,8 +2192,6 @@ const runTests = (baseopts) => {
           await waitForWatcher(watcher);
           await delay(300);
           await write(getFixturePath('add.txt'), 'hello');
-          await delay(300);
-          await fs_unlink(getFixturePath('add.txt'));
         })();
       });
     });
@@ -2216,9 +2214,6 @@ const runTests = (baseopts) => {
           await watcher1.close();
           // Write a new file into the fixtures to test the EV_ADD event
           await write(getFixturePath('add.txt'), 'hello');
-          // Ensures EV_ADD is called. Immediately removing the file causes it to be skipped
-          await delay(200);
-          await fs_unlink(getFixturePath('add.txt'));
         })()
       })
     });


### PR DESCRIPTION
Sometimes, when another process just happened to create a file
when we were setting up a watch, the new file wouldn't be noticed.

To prevent the event not being generated in this case, schedule
a directory rescan immediately after setting up a watch.

Fixes #1112

---
Also, another commit here to fix brittle tests. It might be related to #923