### PR TITLE
Fix no events for symlinks with invalid targets

### DIFF
--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -424,7 +424,10 @@ async _handleSymlink(entry, directory, path, item) {
 
     let linkPath;
     try {
-      linkPath = await fsrealpath(path);
+      linkPath = sysPath.join(
+          await fsrealpath(sysPath.dirname(path)),
+          sysPath.basename(path)
+      );
     } catch (e) {
       this.fsw._emitReady();
       return true;

--- a/test.js
+++ b/test.js
@@ -2133,7 +2133,7 @@ const runTests = (baseopts) => {
         await delay(300);
         await write(testSubDirFile, '');
         await delay(300);
-
+        
         chai.assert.deepStrictEqual(events, [
           `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test')}`,
           `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test', 'dir')}`,

--- a/test.js
+++ b/test.js
@@ -2174,7 +2174,7 @@ const runTests = (baseopts) => {
         await fs_mkdir(testSubDir);
         await write(testSubDirFile, '');
         await delay(300);
-
+        
         chai.assert.deepStrictEqual(events, [
           `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test-link')}`,
           `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test-link', 'dir')}`,


### PR DESCRIPTION
Even with `followSymlinks: false` no events (e.g. 'add') were emitted for links with a target that doesn't exist.
Not sure about the changes / why we even need the realpath if `followSymlinks: false`. Also tests seem to fail (at least locally).
This is more like a draft PR so far (maybe someone can take over or suggest changes).

Steps to repro:
```
const chokidar = require('.');
chokidar.watch('tmp', {
    usePolling: true,
    followSymlinks: false
}).on('all', (e, p) => console.log(e, p));
```

```
ln -s does-not-exist link
```