### PR TITLE
Update FsEventsHandler.handleEvent

### DIFF
--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -266,29 +266,27 @@ handleEvent(event, path, fullPath, realPath, parent, watchedDir, item, info, opt
     if (isDirectory || watchedDir.has(item)) {
       this.fsw._remove(parent, item, isDirectory);
     }
-  } else {
-    if (event === EV_ADD) {
-      // track new directories
-      if (info.type === FSEVENT_TYPE_DIRECTORY) this.fsw._getWatchedDir(path);
+  } else if (event === EV_ADD) {
+    // track new directories
+    if (info.type === FSEVENT_TYPE_DIRECTORY) this.fsw._getWatchedDir(path);
 
-      if (info.type === FSEVENT_TYPE_SYMLINK && opts.followSymlinks) {
-        // push symlinks back to the top of the stack to get handled
-        const curDepth = opts.depth === undefined ?
-          undefined : calcDepth(fullPath, realPath) + 1;
-        return this._addToFsEvents(path, false, true, curDepth);
-      }
-
-      // track new paths
-      // (other than symlinks being followed, which will be tracked soon)
-      this.fsw._getWatchedDir(parent).add(item);
+    if (info.type === FSEVENT_TYPE_SYMLINK && opts.followSymlinks) {
+      // push symlinks back to the top of the stack to get handled
+      const curDepth = opts.depth === undefined ?
+        undefined : calcDepth(fullPath, realPath) + 1;
+      return this._addToFsEvents(path, false, true, curDepth);
     }
-    /**
-     * @type {'add'|'addDir'|'unlink'|'unlinkDir'}
-     */
-    const eventName = info.type === FSEVENT_TYPE_DIRECTORY ? event + DIR_SUFFIX : event;
-    this.fsw._emit(eventName, path);
-    if (eventName === EV_ADD_DIR) this._addToFsEvents(path, false, true);
+
+    // track new paths
+    // (other than symlinks being followed, which will be tracked soon)
+    this.fsw._getWatchedDir(parent).add(item);
   }
+  /**
+   * @type {'add'|'addDir'|'unlink'|'unlinkDir'}
+   */
+  const eventName = info.type === FSEVENT_TYPE_DIRECTORY ? event + DIR_SUFFIX : event;
+  this.fsw._emit(eventName, path);
+  if (eventName === EV_ADD_DIR) this._addToFsEvents(path, false, true);
 }
 
 /**


### PR DESCRIPTION
Allows unlink/unlinkDir events to actually be emitted as expected on macOS.

The previous logic made it so that the call to `this.fsw._emit(eventName, path);` was only ever reachable if the event.type was *not* `EV_UNLINK`.