### PR TITLE
Bump glob-parent to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chokidar",
   "description": "Minimal and efficient cross-platform file watching library",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "homepage": "https://github.com/paulmillr/chokidar",
   "author": "Paul Miller (https://paulmillr.com)",
   "contributors": [
@@ -16,7 +16,7 @@
   "dependencies": {
     "anymatch": "~3.1.2",
     "braces": "~3.0.2",
-    "glob-parent": "~5.1.2",
+    "glob-parent": "~6.0.2",
     "is-binary-path": "~2.1.0",
     "is-glob": "~4.0.1",
     "normalize-path": "~3.0.0",


### PR DESCRIPTION
there is a vulnerability in the current version so updating it to the latest version.