### PR TITLE
(WIP) feat: ignore watches by file ext

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -107,6 +107,11 @@ export interface WatchOptions {
   disableGlobbing?: boolean;
 
   /**
+   * The list of extensions of files to watch.
+   */
+  ext?: string[];
+
+  /**
    * Whether to use fs.watchFile (backed by polling), or fs.watch. If polling leads to high CPU
    * utilization, consider setting this to `false`. It is typically necessary to **set this to
    * `true` to successfully watch files over a network**, and it may be necessary to successfully


### PR DESCRIPTION
## Progress

- [x] Code for ignoring files by extension
- [ ] Tests
- [ ] Docs

## Description

PoC for ignoring watched files by the extension.

## Why?

ATM, there is no option to ignore file watches by file extension. Consequently, other third-party utils implement some extra checks to ignore updates from the unnecessary watches.

Also, it may help with improving performance on #1162.