### PR TITLE
Fix multiple non-existing throttling (#1276)

### DIFF
--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -457,13 +457,31 @@ _handleRead(directory, initialAdd, wh, target, dir, depth, throttler) {
   // Normalize the directory name on Windows
   directory = sysPath.join(directory, EMPTY_STR);
 
+  const current = new Set();
+  const targets = new Set([target]);
+
   if (!wh.hasGlob) {
     throttler = this.fsw._throttle('readdir', directory, 1000);
-    if (!throttler) return;
+    if (!throttler) {
+      const thr = this.fsw._throttled.get('readdir').get(directory);
+      if (thr.current.has(target)) {
+        this.fsw._incrReadyCount();
+
+        // ensure relativeness of path is preserved in case of watcher reuse
+        const path = sysPath.join(dir, sysPath.relative(dir, target));
+
+        this._addToNodeFs(path, initialAdd, wh, depth + 1);
+      } else {
+        thr.targets.add(target);
+      }
+      return;
+    }
+
+    throttler.current = current;
+    throttler.targets = targets;
   }
 
   const previous = this.fsw._getWatchedDir(wh.path);
-  const current = new Set();
 
   let stream = this.fsw._readdirp(directory, {
     fileFilter: entry => wh.filterPath(entry),
@@ -489,7 +507,7 @@ _handleRead(directory, initialAdd, wh, target, dir, depth, throttler) {
     // Files that present in current directory snapshot
     // but absent in previous are added to watch list and
     // emit `add` event.
-    if (item === target || !target && !previous.has(item)) {
+    if (targets.has(item) || !target && !previous.has(item)) {
       this.fsw._incrReadyCount();
 
       // ensure relativeness of path is preserved in case of watcher reuse

--- a/test.js
+++ b/test.js
@@ -622,6 +622,19 @@ const runTests = (baseopts) => {
       spy.withArgs(EV_CHANGE, testPath).should.have.been.calledThrice;
     });
 
+    it('should detect add if multiple files watched in the same directory', async () => {
+      const test1Path = getFixturePath('add1.txt');
+      const test2Path = getFixturePath('add2.txt');
+      const watcher = chokidar_watch([test1Path, test2Path], options);
+      const spy = await aspy(watcher, EV_ALL);
+
+      await delay(300);
+      await write(test2Path, dateNow());
+      await write(test1Path, dateNow());
+      await waitFor([[spy, 2]]);
+      spy.withArgs(EV_ADD, test2Path).should.have.been.calledOnce;
+      spy.withArgs(EV_ADD, test1Path).should.have.been.calledOnce;
+    });
 
     // PR 682 is failing.
     describe.skip('Skipping gh-682: should detect unlink', () => {
@@ -2122,7 +2135,7 @@ const runTests = (baseopts) => {
         await delay(300);
         await write(testSubDirFile, '');
         await delay(300);
-        
+
         chai.assert.deepStrictEqual(events, [
           `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test')}`,
           `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test', 'dir')}`,
@@ -2163,7 +2176,7 @@ const runTests = (baseopts) => {
         await fs_mkdir(testSubDir);
         await write(testSubDirFile, '');
         await delay(300);
-        
+
         chai.assert.deepStrictEqual(events, [
           `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test-link')}`,
           `[ALL] addDir: ${sysPath.join('test-fixtures', id, 'test-link', 'dir')}`,


### PR DESCRIPTION
Previously the subsequent targets under the same directory were throttled and ignored.

In this pull request, `current` and newly added `targets` are added to the `throttler` object so that it can be checked in both the stream events and subsequent `_handleRead` calls.