### PR TITLE
fix readyCount logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,7 +441,7 @@ add(paths_, _origAdd, _internal) {
 
   if (this.options.useFsEvents && this._fsEventsHandler) {
     if (!this._readyCount) this._readyCount = paths.length;
-    if (this.options.persistent) this._readyCount *= 2;
+    if (this.options.persistent) this._readyCount += paths.length;
     paths.forEach((path) => this._fsEventsHandler._addToFsEvents(path));
   } else {
     if (!this._readyCount) this._readyCount = 0;

--- a/test.js
+++ b/test.js
@@ -469,6 +469,17 @@ const runTests = (baseopts) => {
       unlinkSpy.withArgs(newPath1).should.have.been.calledOnce;
       unlinkSpy.withArgs(newPath2).should.not.have.been.called;
     });
+    it('should emit `ready` when three files were added', async () => {
+      const path1 = getFixturePath('add1.txt');
+      const path2 = getFixturePath('add2.txt');
+      const path3 = getFixturePath('add3.txt');
+
+      watcher.add(path1);
+      watcher.add(path2);
+      watcher.add(path3);
+
+      await waitForWatcher(watcher);
+    });
     it('should survive ENOENT for missing subdirectories', async () => {
       const testDir = getFixturePath('notadir');
       await waitForWatcher(watcher);

--- a/test.js
+++ b/test.js
@@ -469,17 +469,6 @@ const runTests = (baseopts) => {
       unlinkSpy.withArgs(newPath1).should.have.been.calledOnce;
       unlinkSpy.withArgs(newPath2).should.not.have.been.called;
     });
-    it('should emit `ready` when three files were added', async () => {
-      const path1 = getFixturePath('add1.txt');
-      const path2 = getFixturePath('add2.txt');
-      const path3 = getFixturePath('add3.txt');
-
-      watcher.add(path1);
-      watcher.add(path2);
-      watcher.add(path3);
-
-      await waitForWatcher(watcher);
-    });
     it('should survive ENOENT for missing subdirectories', async () => {
       const testDir = getFixturePath('notadir');
       await waitForWatcher(watcher);
@@ -560,6 +549,21 @@ const runTests = (baseopts) => {
     });
   });
   describe('watch individual files', () => {
+    it('should emit `ready` when three files were added', async () => {
+      const readySpy = sinon.spy(function readySpy(){});
+      const watcher = chokidar_watch().on(EV_READY, readySpy);
+      const path1 = getFixturePath('add1.txt');
+      const path2 = getFixturePath('add2.txt');
+      const path3 = getFixturePath('add3.txt');
+
+      watcher.add(path1);
+      watcher.add(path2);
+      watcher.add(path3);
+
+      await waitForWatcher(watcher);
+      // callCount is 1 on macOS, 4 on Ubuntu
+      readySpy.callCount.should.be.greaterThanOrEqual(1);
+    });
     it('should detect changes', async () => {
       const testPath = getFixturePath('change.txt');
       const watcher = chokidar_watch(testPath, options);


### PR DESCRIPTION
This PR fixes `readyCount` logic.

Previously the `this._readyCount` will be doubled whenever `watcher.add()` is called, I believe it should have been only doubling the ready count change (hence adding the `paths.length` again) rather than the total counts. After all, calling `watcher.add()` for three times should yield the same `readyCount` as calling it one time with all 3 different paths.

I added a test for this fix. The test hangs forever on macOS because `readyCount` is too large. With the new fix, the `ready` event is emitted as expected.
