### PR TITLE
fix for #1011

### DIFF
--- a/index.js
+++ b/index.js
@@ -447,11 +447,7 @@ add(paths_, _origAdd, _internal) {
     if (!this._readyCount) this._readyCount = 0;
     this._readyCount += paths.length;
     Promise.all(
-      paths.map(async path => {
-        const res = await this._nodeFsHandler._addToNodeFs(path, !_internal, 0, 0, _origAdd);
-        if (res) this._emitReady();
-        return res;
-      })
+      paths.map(async path => await this._nodeFsHandler._addToNodeFs(path, !_internal, 0, 0, _origAdd))
     ).then(results => {
       if (this.closed) return;
       results.filter(item => item).forEach(item => {

--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -642,10 +642,9 @@ async _addToNodeFs(path, initialAdd, priorWh, depth, target) {
     return false;
 
   } catch (error) {
-    if (this.fsw._handleError(error)) {
-      ready();
-      return path;
-    }
+    this.fsw._handleError(error);
+    ready();
+    return path;
   }
 }
 


### PR DESCRIPTION
When the call to ready() has been added to _addToNodeFs a bug has been introduced because it didn't consider that there 
was already a call to _emitReady() in add and the result is that ready get dispatched before all paths are scanned
if one of them has errors.
I am trying to fix that here and I also refactored the catch block to better express the fact that the condition is always true
therefore there isn't a case in which ready() wouldn't have been called.