### PR TITLE
update fs.FSWatcher types to satisfy nodejs versions >= 16; fixes #1299

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,7 +60,7 @@ export class FSWatcher extends EventEmitter implements fs.FSWatcher {
    */
   on(event: 'ready', listener: () => void): this;
 
-  on(event: 'unlink' | 'unlinkDir', listener: (path: string) => void): this;
+  on(event: 'unlink'|'unlinkDir', listener: (path: string) => void): this;
 
   on(event: string, listener: (...args: any[]) => void): this;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,9 +60,13 @@ export class FSWatcher extends EventEmitter implements fs.FSWatcher {
    */
   on(event: 'ready', listener: () => void): this;
 
-  on(event: 'unlink'|'unlinkDir', listener: (path: string) => void): this;
+  on(event: 'unlink' | 'unlinkDir', listener: (path: string) => void): this;
 
   on(event: string, listener: (...args: any[]) => void): this;
+
+  ref(): this;
+  
+  unref(): this;
 }
 
 export interface WatchOptions {


### PR DESCRIPTION
Fix for #1299.

The `ref` and `unref` methods have been in `fs.FSWatcher` since node v14, a version which hit eol on [2023-04-30](https://github.com/nodejs/Release). These types should be added to support types on currently supported node versions.

Although these changes to node were made in v14, it doesn't seem like the types were updated until v16, which is perhaps part of the confusion (devDependencies @types/node is pinned to 14).