### PR TITLE
Fix filter pattern not being applied to files inside symlink subdirectories of the watched path

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,7 +252,6 @@ class WatchHelper {
     const resolvedPath = this.entryPath(entry);
     const matchesGlob = this.hasGlob && typeof this.globFilter === FUNCTION_TYPE ?
       this.globFilter(resolvedPath) : true;
-
     return matchesGlob &&
       this.fsw._isntIgnored(resolvedPath, stats) &&
       this.fsw._hasReadPermissions(stats);

--- a/lib/fsevents-handler.js
+++ b/lib/fsevents-handler.js
@@ -369,7 +369,7 @@ _watchWithFsEvents(watchPath, realPath, transform, globFilter) {
  * @param {Number} curDepth level of subdirectories traversed to where symlink is
  * @returns {Promise<void>}
  */
-async _handleFsEventsSymlink(linkPath, fullPath, transform, curDepth) {
+async _handleFsEventsSymlink(linkPath, fullPath, transform, curDepth, watchHelpers) {
   // don't follow the same symlink more than once
   if (this.fsw.closed || this.fsw._symlinkPaths.has(fullPath)) return;
 
@@ -387,15 +387,21 @@ async _handleFsEventsSymlink(linkPath, fullPath, transform, curDepth) {
 
     // add the linkTarget for watching with a wrapper for transform
     // that causes emitted paths to incorporate the link's path
-    this._addToFsEvents(linkTarget || linkPath, (path) => {
-      let aliasedPath = linkPath;
-      if (linkTarget && linkTarget !== DOT_SLASH) {
-        aliasedPath = path.replace(linkTarget, linkPath);
-      } else if (path !== DOT_SLASH) {
-        aliasedPath = sysPath.join(linkPath, path);
-      }
-      return transform(aliasedPath);
-    }, false, curDepth);
+    this._addToFsEvents(
+      linkTarget || linkPath,
+      (path) => {
+        let aliasedPath = linkPath;
+        if (linkTarget && linkTarget !== DOT_SLASH) {
+          aliasedPath = path.replace(linkTarget, linkPath);
+        } else if (path !== DOT_SLASH) {
+          aliasedPath = sysPath.join(linkPath, path);
+        }
+        return transform(aliasedPath);
+      },
+      false,
+      curDepth,
+      watchHelpers
+    );
   } catch(error) {
     if (this.fsw._handleError(error)) {
       return this.fsw._emitReady();
@@ -441,16 +447,17 @@ initWatch(realPath, path, wh, processPath) {
  * @param {Function|Boolean=} transform converts working path to what the user expects
  * @param {Boolean=} forceAdd ensure add is emitted
  * @param {Number=} priorDepth Level of subdirectories already traversed.
+ * @param {WatchHelpers=} parentWatchHelpers Parent directory's watch helper in the case of a symlink'd subdir
  * @returns {Promise<void>}
  */
-async _addToFsEvents(path, transform, forceAdd, priorDepth) {
+async _addToFsEvents(path, transform, forceAdd, priorDepth, parentWatchHelpers) {
   if (this.fsw.closed) {
     return;
   }
   const opts = this.fsw.options;
   const processPath = typeof transform === FUNCTION_TYPE ? transform : IDENTITY_FN;
 
-  const wh = this.fsw._getWatchHelpers(path);
+  const wh = this.fsw._getWatchHelpers(path, undefined, parentWatchHelpers);
 
   // evaluate what is at the path we're being asked to watch
   try {
@@ -487,7 +494,7 @@ async _addToFsEvents(path, transform, forceAdd, priorDepth) {
           const curDepth = opts.depth === undefined ?
             undefined : calcDepth(joinedPath, sysPath.resolve(wh.watchPath)) + 1;
 
-          this._handleFsEventsSymlink(joinedPath, fullPath, processPath, curDepth);
+          this._handleFsEventsSymlink(joinedPath, fullPath, processPath, curDepth, wh);
         } else {
           this.emitAdd(joinedPath, entry.stats, processPath, opts, forceAdd);
         }

--- a/test.js
+++ b/test.js
@@ -15,8 +15,6 @@ const upath = require('upath');
 const {isWindows, isMacos, isIBMi, EV_ALL, EV_READY, EV_ADD, EV_CHANGE, EV_ADD_DIR, EV_UNLINK, EV_UNLINK_DIR, EV_RAW, EV_ERROR}
     = require('./lib/constants');
 const chokidar = require('.');
-const { cpuUsage } = require('process');
-const api = require('sinon');
 
 const {expect} = chai;
 chai.use(sinonChai);
@@ -71,6 +69,7 @@ const delay = async (time) => {
     setTimeout(resolve, timer);
   });
 };
+
 const getFixturePath = (subPath) => {
   const subd = subdirId && subdirId.toString() || '';
   return sysPath.join(FIXTURES_PATH, subd, subPath);

--- a/test.js
+++ b/test.js
@@ -1276,23 +1276,18 @@ const runTests = (baseopts) => {
     let realDir;
     let watchDir;
     let linkDir;
-    let aPath;
-    let bPath;
 
     beforeEach(async () => {
       realDir = sysPath.join(currentDir, 'realSubdir');
       watchDir = sysPath.join(currentDir, 'watchDir');
       linkDir = sysPath.join(watchDir, 'linkSubdir');
 
-      aPath = sysPath.join(realDir, 'a.a');
-      bPath = sysPath.join(realDir, 'b.b');
-
       await fs_mkdir(realDir, PERM_ARR);
       await fs_mkdir(watchDir, PERM_ARR);
       await fs_symlink(realDir, linkDir);
 
-      await write(aPath, 'aaa');
-      await write(bPath, 'bbb');
+      await write(sysPath.join(realDir, 'a.a'), 'aaa');
+      await write(sysPath.join(realDir, 'b.b'), 'bbb');
       return true;
     });
     afterEach(async () => {
@@ -1300,18 +1295,18 @@ const runTests = (baseopts) => {
       return true;
     });
     it('should properly match glob patterns that include a symlinked subdir', async () => {
-      const dirSpy = sinon.spy(function dirSpy() { });
-      const addSpy = sinon.spy(function addSpy() { });
+      const dirSpy = sinon.spy(function dirSpy() {});
+      const addSpy = sinon.spy(function addSpy() {});
       const watchPattern = upath.join(watchDir, '**/*.a');
       const watcher = chokidar_watch(watchPattern, options)
         .on(EV_ADD_DIR, dirSpy)
         .on(EV_ADD, addSpy);
       await waitForWatcher(watcher);
       addSpy.should.have.been.calledOnce;
-      addSpy.should.have.been.calledWith(aPath);
-      await write(sysPath.join(realDir, 'a2.a'), 'a2');
+      addSpy.should.have.been.calledWith(sysPath.join(linkDir, 'a.a'));
       await write(sysPath.join(realDir, 'b2.b'), 'b2');
-      await waitFor([[addSpy, 4]]);
+      await write(sysPath.join(realDir, 'a2.a'), 'a2');
+      await waitFor([[addSpy, 2]]);
       addSpy.should.have.been.calledWith(sysPath.join(linkDir, 'a2.a'));
     });
   });


### PR DESCRIPTION
This PR resolves issue #967 and applies the pattern filter to files nested inside symlinks. 

No change in expected behavior or usage. New passing test added. 