### PR TITLE
test: switch to node test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "version": "4.0.0-alpha",
   "homepage": "https://github.com/paulmillr/chokidar",
   "author": "Paul Miller (https://paulmillr.com)",
-  "contributors": ["Paul Miller (https://paulmillr.com)", "Elan Shanker"],
+  "contributors": [
+    "Paul Miller (https://paulmillr.com)",
+    "Elan Shanker"
+  ],
   "engines": {
     "node": ">= 18"
   },
@@ -21,14 +24,16 @@
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "chai": "4.3.4",
     "eslint": "8.7.0",
-    "mocha": "9.1.4",
     "rimraf": "5.0.5",
     "sinon": "12.0.1",
     "sinon-chai": "3.7.0",
     "typescript": "5.4.2",
     "upath": "2.0.1"
   },
-  "files": ["lib/*.js", "lib/*.d.ts"],
+  "files": [
+    "lib/*.js",
+    "lib/*.d.ts"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/paulmillr/chokidar.git"
@@ -40,9 +45,16 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint --ext=ts --report-unused-disable-directives --ignore-path .gitignore .",
-    "mocha": "mocha --exit --timeout 90000",
-    "test": "npm run build && npm run lint && npm run mocha"
+    "test": "npm run build && npm run lint && node --test"
   },
-  "keywords": ["fs", "watch", "watchFile", "watcher", "watching", "file", "fsevents"],
+  "keywords": [
+    "fs",
+    "watch",
+    "watchFile",
+    "watcher",
+    "watching",
+    "file",
+    "fsevents"
+  ],
   "funding": "https://paulmillr.com/funding/"
 }


### PR DESCRIPTION
Switches to using the built-in node test runner and drops mocha.

Temporarily also introduces a `TEST_TIMEOUT` as `--test-timeout` is only available in 20.x and above, but we run CI in 18.x.