### PR TITLE
Bump braces package to 3.0.3. Regenerate package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,20 +7,10 @@
     "": {
       "name": "chokidar",
       "version": "3.6.0",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/paulmillr"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
+        "braces": "~3.0.3",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -41,6 +31,9 @@
       },
       "engines": {
         "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -786,11 +779,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1763,9 +1756,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "types": "./types/index.d.ts",
   "dependencies": {
     "anymatch": "~3.1.2",
-    "braces": "~3.0.2",
+    "braces": "~3.0.3",
     "glob-parent": "~5.1.2",
     "is-binary-path": "~2.1.0",
     "is-glob": "~4.0.1",


### PR DESCRIPTION
Stops referencing a version of braces which contains a vulnerability https://security.snyk.io/package/npm/braces/3.0.2