### PR TITLE
Upgrade braces to v3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,20 +7,10 @@
     "": {
       "name": "chokidar",
       "version": "3.6.0",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/paulmillr"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
+        "braces": "~3.0.3",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -41,6 +31,9 @@
       },
       "engines": {
         "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -786,11 +779,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1763,9 +1756,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "types": "./types/index.d.ts",
   "dependencies": {
     "anymatch": "~3.1.2",
-    "braces": "~3.0.2",
+    "braces": "~3.0.3",
     "glob-parent": "~5.1.2",
     "is-binary-path": "~2.1.0",
     "is-glob": "~4.0.1",


### PR DESCRIPTION
braces v3.0.2 is vulnerable to [CVE-2024-4068](https://www.cve.org/CVERecord?id=CVE-2024-4068) : https://security.snyk.io/vuln/SNYK-JS-BRACES-6838727. This has been fixed in v3.0.3.

This PR just updates the dependency.

Diff: https://github.com/micromatch/braces/compare/3.0.2...3.0.3

Note: `npm test` _is_ failing on my branch... but I see the same test failures on the head of `master` in this repo, so I'm assuming they're known problems. I'm running a macbook pro on macOS 14.5 w/ the Apple M1 Pro chip. 

```
  334 passing (2m)
  18 pending
  6 failing

  1) chokidar
       fsevents (native extension)
         watch symlinks
           should survive ENOENT for missing symlinks when followSymlinks:false:
     AssertionError: expected spy to have been called exactly twice, but it was called thrice
    spy('addDir', '/Users/davebemiller/Code/chokidar/test-fixtures/49/subdir', Stats {
  dev: 16777234,
  mode: 16877,
  nlink: 4,
  uid: 501,
  gid: 20,
  rdev: 0,
  blksize: 4096,
  ino: 6008828,
  size: 128,
  blocks: 0,
  atimeMs: 1718932372713.1387,
  mtimeMs: 1718932372714.0151,
  ctimeMs: 1718932372714.0151,
  birthtimeMs: 1718932372713.1387,
  atime: 2024-06-21T01:12:52.713Z,
  mtime: 2024-06-21T01:12:52.714Z,
  ctime: 2024-06-21T01:12:52.714Z,
  birthtime: 2024-06-21T01:12:52.713Z
}) at FSWatcher.emit (node:events:518:28)

    spy('add', '/Users/davebemiller/Code/chokidar/test-fixtures/49/subdir/add.txt', Stats {
  dev: 16777234,
  mode: 33188,
  nlink: 1,
  uid: 501,
  gid: 20,
  rdev: 0,
  blksize: 4096,
  ino: 6008829,
  size: 1,
  blocks: 8,
  atimeMs: 1718932372713.393,
  mtimeMs: 1718932372713.5144,
  ctimeMs: 1718932372713.5144,
  birthtimeMs: 1718932372713.393,
  atime: 2024-06-21T01:12:52.713Z,
  mtime: 2024-06-21T01:12:52.714Z,
  ctime: 2024-06-21T01:12:52.714Z,
  birthtime: 2024-06-21T01:12:52.713Z
}) at FSWatcher.emit (node:events:518:28)

    spy('add', '/Users/davebemiller/Code/chokidar/test-fixtures/49/subdir/broken', Stats {
  dev: 16777234,
  mode: 41453,
  nlink: 1,
  uid: 501,
  gid: 20,
  rdev: 0,
  blksize: 4096,
  ino: 6008831,
  size: 69,
  blocks: 0,
  atimeMs: 1718932372713.906,
  mtimeMs: 1718932372713.906,
  ctimeMs: 1718932372713.906,
  birthtimeMs: 1718932372713.906,
  atime: 2024-06-21T01:12:52.714Z,
  mtime: 2024-06-21T01:12:52.714Z,
  ctime: 2024-06-21T01:12:52.714Z,
  birthtime: 2024-06-21T01:12:52.714Z
}) at FSWatcher.emit (node:events:518:28)
      at Context.<anonymous> (test.js:1200:28)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

  2) chokidar
       fsevents (native extension)
         watch symlinks
           should watch symlinks within a watched dir as files when followSymlinks:false:
     AssertionError: expected spy to not have been called with arguments 'add', '/Users/davebemiller/Code/chokidar/test-fixtures/50/link/add.txt'
      at Context.<anonymous> (test.js:1220:32)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

  3) chokidar
       fsevents (native extension)
         reproduction of bug in issue #1024
           should detect changes to symlink folders, even if they were deleted before:

      AssertionError: expected [ …(2) ] to deeply equal [ …(5) ]
      + expected - actual

       [
         "[ALL] addDir: test-fixtures/110/test-link"
         "[ALL] addDir: test-fixtures/110/test-link/dir"
      +  "[ALL] unlinkDir: test-fixtures/110/test-link/dir"
      +  "[ALL] addDir: test-fixtures/110/test-link/dir"
      +  "[ALL] add: test-fixtures/110/test-link/dir/file"
       ]
      
      at Context.<anonymous> (test.js:2182:21)

  4) chokidar
       fs.watch (non-polling)
         watch individual files
           should detect safe-edit:
     AssertionError: expected spy to have been called exactly thrice, but it was called once
    spy('change', '/Users/davebemiller/Code/chokidar/test-fixtures/138/change.txt', Stats {
  dev: 16777234,
  mode: 33188,
  nlink: 1,
  uid: 501,
  gid: 20,
  rdev: 0,
  blksize: 4096,
  ino: 6009923,
  size: 13,
  blocks: 8,
  atimeMs: 1718932409151.3308,
  mtimeMs: 1718932409151.812,
  ctimeMs: 1718932409152.492,
  birthtimeMs: 1718932409151.3308,
  atime: 2024-06-21T01:13:29.151Z,
  mtime: 2024-06-21T01:13:29.152Z,
  ctime: 2024-06-21T01:13:29.152Z,
  birthtime: 2024-06-21T01:13:29.151Z
})
      at Context.<anonymous> (test.js:637:57)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

  5) chokidar
       fs.watch (non-polling)
         reproduction of bug in issue #1024
           should detect changes to symlink folders, even if they were deleted before:

      AssertionError: expected [ …(2) ] to deeply equal [ …(5) ]
      + expected - actual

       [
         "[ALL] addDir: test-fixtures/223/test-link"
         "[ALL] addDir: test-fixtures/223/test-link/dir"
      +  "[ALL] unlinkDir: test-fixtures/223/test-link/dir"
      +  "[ALL] addDir: test-fixtures/223/test-link/dir"
      +  "[ALL] add: test-fixtures/223/test-link/dir/file"
       ]
      
      at Context.<anonymous> (test.js:2182:21)

  6) chokidar
       fs.watchFile (polling)
         reproduction of bug in issue #1024
           should detect changes to symlink folders, even if they were deleted before:

      AssertionError: expected [ …(2) ] to deeply equal [ …(5) ]
      + expected - actual

       [
         "[ALL] addDir: test-fixtures/336/test-link"
         "[ALL] addDir: test-fixtures/336/test-link/dir"
      +  "[ALL] unlinkDir: test-fixtures/336/test-link/dir"
      +  "[ALL] addDir: test-fixtures/336/test-link/dir"
      +  "[ALL] add: test-fixtures/336/test-link/dir/file"
       ]
      
      at Context.<anonymous> (test.js:2182:21)



error Command failed with exit code 6.
```