### PR TITLE
feat: move to node:fs/promises

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import { EventEmitter } from 'node:events';
 import sysPath from 'node:path';
-import { promisify } from 'node:util';
 import readdirp from 'readdirp';
+import {stat, readdir} from 'node:fs/promises';
 
 import NodeFsHandler from './nodefs-handler.js';
 import { anymatch, MatchFunction, isMatcherObject, Matcher } from './anymatch.js';
@@ -27,9 +27,6 @@ import {
 } from './constants.js';
 import * as EV from './events.js';
 import { EventName } from './events.js';
-
-const stat = promisify(fs.stat);
-const readdir = promisify(fs.readdir);
 
 type ThrottleType = 'readdir' | 'watch' | 'add' | 'remove' | 'change';
 type EmitArgs = [EventName, Path, any?, any?, any?];

--- a/test.mjs
+++ b/test.mjs
@@ -484,7 +484,7 @@ const runTests = (baseopts) => {
       await waitFor([unlinkSpy.withArgs(testPath)]);
       unlinkSpy.should.have.been.calledWith(testPath);
 
-      await delay();
+      await delay(100);
       await write(testPath, dateNow());
       await waitFor([[addSpy.withArgs(testPath), 2]]);
       addSpy.should.have.been.calledWith(testPath);
@@ -1414,15 +1414,17 @@ const runTests = (baseopts) => {
         });
         options2.cwd = getFixturePath('subdir');
         const watcher = chokidar_watch(getGlobPath('.'), options);
+        const watcherEvents = waitForEvents(watcher, 3);
         const spy1 = await aspy(watcher, EV.ALL);
 
         await delay();
         const watcher2 = chokidar_watch(currentDir, options2);
+        const watcher2Events = waitForEvents(watcher2, 5);
         const spy2 = await aspy(watcher2, EV.ALL);
 
         await fs_unlink(getFixturePath('unlink.txt'));
         await write(getFixturePath('change.txt'), dateNow());
-        await waitFor([spy1.withArgs(EV.UNLINK), spy2.withArgs(EV.UNLINK)]);
+        await Promise.all([watcherEvents, watcher2Events]);
         spy1.should.have.been.calledWith(EV.CHANGE, 'change.txt');
         spy1.should.have.been.calledWith(EV.UNLINK, 'unlink.txt');
         spy2.should.have.been.calledWith(EV.ADD, sysPath.join('..', 'change.txt'));


### PR DESCRIPTION
Moves to using `node:fs/promises` rather than using `promisify` manually.