### PR TITLE
Update braces to version 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "types": "./types/index.d.ts",
   "dependencies": {
     "anymatch": "~3.1.2",
-    "braces": "~3.0.2",
+    "braces": "~3.0.3",
     "glob-parent": "~5.1.2",
     "is-binary-path": "~2.1.0",
     "is-glob": "~4.0.1",


### PR DESCRIPTION
The `braces` package versions before 3.0.3 are vulnerable to  CVE-2024-4068 - see https://github.com/advisories/GHSA-grv7-fg5c-xmjg

This PR bumps the `braces` package version to 3.0.3