### PR TITLE
fix: consider atime == mtime to be a non-change

### DIFF
--- a/src/nodefs-handler.ts
+++ b/src/nodefs-handler.ts
@@ -372,17 +372,15 @@ export default class NodeFsHandler {
     if (parent.has(basename)) return;
 
     const listener = async (path, newStats) => {
-      console.log({path, newStats});
       if (!this.fsw._throttle(THROTTLE_MODE_WATCH, file, 5)) return;
       if (!newStats || newStats.mtimeMs === 0) {
         try {
           const newStats = await stat(file);
-          console.log({newStats, prevStats});
           if (this.fsw.closed) return;
           // Check that change event was not fired because of changed only accessTime.
           const at = newStats.atimeMs;
           const mt = newStats.mtimeMs;
-          if (!at || at <= mt || mt !== prevStats.mtimeMs) {
+          if (!at || at < mt || mt !== prevStats.mtimeMs) {
             this.fsw._emit(EV.CHANGE, file, newStats);
           }
           if ((isMacos || isLinux) && prevStats.ino !== newStats.ino) {
@@ -393,7 +391,6 @@ export default class NodeFsHandler {
             prevStats = newStats;
           }
         } catch (error) {
-          console.log({error});
           // Fix issues where mtime is null but file is still present
           this.fsw._remove(dirname, basename);
         }

--- a/test.mjs
+++ b/test.mjs
@@ -9,6 +9,13 @@ import {rimraf} from 'rimraf';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import upath from 'upath';
+import {
+  symlink as fs_symlink,
+  rename as fs_rename,
+  mkdir as fs_mkdir,
+  rmdir as fs_rmdir,
+  unlink as fs_unlink
+} from 'node:fs/promises';
 
 import chokidar from './lib/index.js';
 import * as EV from './lib/events.js';
@@ -26,11 +33,6 @@ chai.should();
 
 const exec = promisify(childProcess.exec);
 const write = promisify(fs.writeFile);
-const fs_symlink = promisify(fs.symlink);
-const fs_rename = promisify(fs.rename);
-const fs_mkdir = promisify(fs.mkdir);
-const fs_rmdir = promisify(fs.rmdir);
-const fs_unlink = promisify(fs.unlink);
 
 const FIXTURES_PATH_REL = 'test-fixtures';
 const FIXTURES_PATH = sysPath.join(__dirname, FIXTURES_PATH_REL);


### PR DESCRIPTION
Changes the file listener to treat `atime === mtime` as a non-change.

Currently, if these are equal, we fire a `CHANGE` event which causes bugs on windows (as windows emits two change events when you first write).