### PR TITLE
docs(README): add missing conversion from async generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ chok.watch('./directory');
 
 // other way
 import { glob } from 'node:fs/promises';
-const watcher = watch(await glob('**/*.js'));
+const watcher = watch(await Array.fromAsync(glob('**/*.js')));
 
 // unwatching
 // v3


### PR DESCRIPTION
Add missing conversion from async generator to the v4 migration docs.

As mentioned https://github.com/paulmillr/chokidar/issues/1350#issuecomment-2371324673 node actually returns an async generator from its glob function. We can use `Array.fromAsync` to convert it to an array promise. This array method was added rather recently (v22), but if you are using node's glob you also have it.