### PR TITLE
Fix test "should detect safe-edit" on FreeBSD

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -18,6 +18,7 @@ const pl = process.platform;
 export const isWindows = pl === 'win32';
 export const isMacos = pl === 'darwin';
 export const isLinux = pl === 'linux';
+export const isFreeBSD = pl === 'freebsd';
 export const isIBMi = osType() === 'OS400';
 
 export const EVENTS = {
@@ -433,7 +434,7 @@ export class NodeFsHandler {
           if (!at || at <= mt || mt !== prevStats.mtimeMs) {
             this.fsw._emit(EV.CHANGE, file, newStats);
           }
-          if ((isMacos || isLinux) && prevStats.ino !== newStats.ino) {
+          if ((isMacos || isLinux || isFreeBSD) && prevStats.ino !== newStats.ino) {
             this.fsw._closeFile(path);
             prevStats = newStats;
             const closer = this._watchWithNodeFs(file, listener);


### PR DESCRIPTION
Without the proposed changes, 1 test fails on FreeBSD with the following message.

```
ℹ tests 207
ℹ suites 59
ℹ pass 206
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 55152.343001

✖ failing tests:

test at test.mjs:658:5
✖ should detect safe-edit (1033.198101ms)
  "[Error [ERR_TEST_FAILURE]: expected spy to have been called exactly thrice, but it was called once\n    spy('change', '/usr/home/tagattie/tmp/chokidar/test-fixtures/25/change.txt', { dev: 13583154299369583000,\n  mode: 33188,\n  nlink: 1,\n  uid: 1001,\n  gid: 1001,\n  rdev: 0,\n  blksize: 4096,\n  ino: 614134,\n  size: 13,\n  blocks: 1,\n  atimeMs: 1729365887227.83,\n  mtimeMs: 1729365887228.057,\n  ctimeMs: 1729365887228.36,\n  birthtimeMs: 1729365887227.83,\n  atime: Sun Oct 20 2024 04:24:47 GMT+0900 (Japan Standard Time),\n  mtime: Sun Oct 20 2024 04:24:47 GMT+0900 (Japan Standard Time),\n  ctime: Sun Oct 20 2024 04:24:47 GMT+0900 (Japan Standard Time),\n  birthtime: Sun Oct 20 2024 04:24:47 GMT+0900 (Japan Standard Time) })] {\n  code: 'ERR_TEST_FAILURE',\n  failureType: 'testCodeFailure',\n  cause: AssertionError: expected spy to have been called exactly thrice, but it was called once\n      spy('change', '/usr/home/tagattie/tmp/chokidar/test-fixtures/25/change.txt', { dev: 13583154299369583000,\n    mode: 33188,\n    nlink: 1,\n    uid: 1001,\n    gid: 1001,\n    rdev: 0,\n    blksize: 4096,\n    ino: 614134,\n    size: 13,\n    blocks: 1,\n    atimeMs: 1729365887227.83,\n    mtimeMs: 1729365887228.057,\n    ctimeMs: 1729365887228.36,\n    birthtimeMs: 1729365887227.83,\n    atime: Sun Oct 20 2024 04:24:47 GMT+0900 (Japan Standard Time),\n    mtime: Sun Oct 20 2024 04:24:47 GMT+0900 (Japan Standard Time),\n    ctime: Sun Oct 20 2024 04:24:47 GMT+0900 (Japan Standard Time),\n    birthtime: Sun Oct 20 2024 04:24:47 GMT+0900 (Japan Standard Time) })\n      at TestContext.<anonymous> (file:///usr/home/tagattie/tmp/chokidar/test.mjs:676:57)\n      at async Test.run (node:internal/test_runner/test:797:9)\n      at async Suite.processPendingSubtests (node:internal/test_runner/test:527:7) {\n    showDiff: false,\n    actual: [Function: funk] {\n      matchingArguments: [Array],\n      parent: [Function (anonymous)]\n    },\n    expected: undefined\n  }\n}"

test at test.mjs:590:3
✖ watch individual files (1364.583595ms)
  [Error [ERR_TEST_FAILURE]: 1 subtest failed] { [cause]: '1 subtest failed' }

test at test.mjs:2132:5
✖ fs.watch (non-polling) (25868.895511ms)
  [Error [ERR_TEST_FAILURE]: 1 subtest failed] { [cause]: '1 subtest failed' }

test at test.mjs:2093:1
✖ chokidar (54048.639241ms)
  [Error [ERR_TEST_FAILURE]: 1 subtest failed] { [cause]: '1 subtest failed' }
```

Versions:

- Chokidar version: latest main
- Node version: 20.18.0
- OS Version: FreeBSD 14.1

To reproduce:

Execute the following commands:

```
npm ci
npm run build
npm run test
```

After applying the proposed changes, all tests pass.
