### PR TITLE
Remove references to .map files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /node_modules/
 /test-fixtures/
 /*.d.ts
-/*.map
 /index.js
 /handler.js
 /esm

--- a/package.json
+++ b/package.json
@@ -7,12 +7,8 @@
   "files": [
     "index.js",
     "index.d.ts",
-    "index.d.ts.map",
-    "index.js.map",
     "handler.js",
     "handler.d.ts",
-    "handler.d.ts.map",
-    "handler.js.map",
     "esm"
   ],
   "main": "./index.js",


### PR DESCRIPTION
With https://github.com/paulmillr/chokidar/commit/8c730acb9cd262d86ece1956969eac26d74f809a, we can also remove unneeded references to the `.map` files.