### PR TITLE
test: switch to node:fs/promises

### DIFF
--- a/test.mjs
+++ b/test.mjs
@@ -1,6 +1,6 @@
-import fs, { writeFileSync } from 'node:fs'; // fs.stat is mocked below, so can't import INDIVIDUAL methods
+import fs from 'node:fs'; // fs.stat is mocked below, so can't import INDIVIDUAL methods
+import * as fsp from 'node:fs/promises';
 import sysPath from 'node:path';
-// import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
 import { describe, it, beforeEach, afterEach } from 'micro-should';
 import { fileURLToPath, pathToFileURL, URL } from 'node:url';
 import { promisify } from 'node:util';
@@ -21,14 +21,6 @@ chai.use(sinonChai);
 chai.should();
 
 const exec = promisify(cexec);
-const rm = promisify(fs.rm);
-const read = promisify(fs.readFile);
-const write = promisify(fs.writeFile);
-const fs_symlink = promisify(fs.symlink);
-const fs_rename = promisify(fs.rename);
-const fs_mkdir = promisify(fs.mkdir);
-const fs_rmdir = promisify(fs.rmdir);
-const fs_unlink = promisify(fs.unlink);
 
 const imetaurl = import.meta.url;
 const __filename = fileURLToPath(new URL('', imetaurl));
@@ -205,7 +197,7 @@ const runTests = (baseopts) => {
       const spy = sinon.spy(function addSpy() {});
       watcher.on(EV.ADD, spy);
       await delay();
-      await write(testPath, dateNow());
+      await fsp.writeFile(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.been.calledOnce;
       spy.should.have.been.calledWith(testPath);
@@ -223,19 +215,19 @@ const runTests = (baseopts) => {
         spy(path);
       });
 
-      write(paths[0], dateNow());
-      write(paths[1], dateNow());
-      write(paths[2], dateNow());
-      write(paths[3], dateNow());
-      write(paths[4], dateNow());
+      await fsp.writeFile(paths[0], dateNow());
+      await fsp.writeFile(paths[1], dateNow());
+      await fsp.writeFile(paths[2], dateNow());
+      await fsp.writeFile(paths[3], dateNow());
+      await fsp.writeFile(paths[4], dateNow());
       await delay(100);
 
-      write(paths[5], dateNow());
-      write(paths[6], dateNow());
+      await fsp.writeFile(paths[5], dateNow());
+      await fsp.writeFile(paths[6], dateNow());
 
       await delay(150);
-      write(paths[7], dateNow());
-      write(paths[8], dateNow());
+      await fsp.writeFile(paths[7], dateNow());
+      await fsp.writeFile(paths[8], dateNow());
 
       await waitFor([[spy, 4]]);
 
@@ -281,14 +273,14 @@ const runTests = (baseopts) => {
       const test9Path = dpath('add9.txt');
       const testb9Path = dpath('b/add9.txt');
       const testc9Path = dpath('c/add9.txt');
-      await fs_mkdir(dpath('b'), PERM);
-      await fs_mkdir(dpath('c'), PERM);
-      await fs_mkdir(dpath('d'), PERM);
-      await fs_mkdir(dpath('e'), PERM);
-      await fs_mkdir(dpath('f'), PERM);
-      await fs_mkdir(dpath('g'), PERM);
-      await fs_mkdir(dpath('h'), PERM);
-      await fs_mkdir(dpath('i'), PERM);
+      await fsp.mkdir(dpath('b'), PERM);
+      await fsp.mkdir(dpath('c'), PERM);
+      await fsp.mkdir(dpath('d'), PERM);
+      await fsp.mkdir(dpath('e'), PERM);
+      await fsp.mkdir(dpath('f'), PERM);
+      await fsp.mkdir(dpath('g'), PERM);
+      await fsp.mkdir(dpath('h'), PERM);
+      await fsp.mkdir(dpath('i'), PERM);
 
       await delay();
 
@@ -335,7 +327,7 @@ const runTests = (baseopts) => {
       let currentCallCount = 0;
 
       for (const fileToWrite of filesToWrite) {
-        await write(fileToWrite, dateNow());
+        await fsp.writeFile(fileToWrite, dateNow());
         await waitFor([[spy, ++currentCallCount]]);
       }
 
@@ -378,7 +370,7 @@ const runTests = (baseopts) => {
       const spy = sinon.spy(function addDirSpy() {});
       watcher.on(EV.ADD_DIR, spy);
       spy.should.not.have.been.called;
-      await fs_mkdir(testDir, PERM);
+      await fsp.mkdir(testDir, PERM);
       await waitFor([spy]);
       spy.should.have.been.calledOnce;
       spy.should.have.been.calledWith(testDir);
@@ -390,7 +382,7 @@ const runTests = (baseopts) => {
       const spy = sinon.spy(function changeSpy() {});
       watcher.on(EV.CHANGE, spy);
       spy.should.not.have.been.called;
-      await write(testPath, dateNow());
+      await fsp.writeFile(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.been.calledWith(testPath);
       expect(spy.args[0][1]).to.be.ok; // stats
@@ -402,7 +394,7 @@ const runTests = (baseopts) => {
       const spy = sinon.spy(function unlinkSpy() {});
       watcher.on(EV.UNLINK, spy);
       spy.should.not.have.been.called;
-      await fs_unlink(testPath);
+      await fsp.unlink(testPath);
       await waitFor([spy]);
       spy.should.have.been.calledWith(testPath);
       expect(spy.args[0][1]).to.not.be.ok; // no stats
@@ -413,11 +405,11 @@ const runTests = (baseopts) => {
       const testDir = dpath('subdir');
       const spy = sinon.spy(function unlinkDirSpy() {});
 
-      await fs_mkdir(testDir, PERM);
+      await fsp.mkdir(testDir, PERM);
       await delay(300);
       watcher.on(EV.UNLINK_DIR, spy);
 
-      await fs_rmdir(testDir);
+      await fsp.rmdir(testDir);
       await waitFor([spy]);
       spy.should.have.been.calledWith(testDir);
       expect(spy.args[0][1]).to.not.be.ok; // no stats
@@ -430,14 +422,14 @@ const runTests = (baseopts) => {
       const testDir3 = dpath('subdir/subdir2/subdir3');
       const spy = sinon.spy(function unlinkDirSpy() {});
 
-      await fs_mkdir(testDir, PERM);
-      await fs_mkdir(testDir2, PERM);
-      await fs_mkdir(testDir3, PERM);
+      await fsp.mkdir(testDir, PERM);
+      await fsp.mkdir(testDir2, PERM);
+      await fsp.mkdir(testDir3, PERM);
       await delay(300);
 
       watcher.on(EV.UNLINK_DIR, spy);
 
-      await rm(testDir2, { recursive: true });
+      await fsp.rm(testDir2, { recursive: true });
       await waitFor([[spy, 2]]);
 
       spy.should.have.been.calledWith(testDir2);
@@ -456,7 +448,7 @@ const runTests = (baseopts) => {
       addSpy.should.not.have.been.called;
 
       await delay();
-      await fs_rename(testPath, newPath);
+      await fsp.rename(testPath, newPath);
       await waitFor([unlinkSpy, addSpy]);
       unlinkSpy.should.have.been.calledWith(testPath);
       expect(unlinkSpy.args[0][1]).to.not.be.ok; // no stats
@@ -476,16 +468,16 @@ const runTests = (baseopts) => {
       const changeSpy = sinon.spy(function change() {});
       const testPath = dpath('add.txt');
       watcher.on(EV.UNLINK, unlinkSpy).on(EV.ADD, addSpy).on(EV.CHANGE, changeSpy);
-      await write(testPath, 'hello');
+      await fsp.writeFile(testPath, 'hello');
       await waitFor([[addSpy.withArgs(testPath), 1]]);
       unlinkSpy.should.not.have.been.called;
       changeSpy.should.not.have.been.called;
-      await fs_unlink(testPath);
+      await fsp.unlink(testPath);
       await waitFor([unlinkSpy.withArgs(testPath)]);
       unlinkSpy.should.have.been.calledWith(testPath);
 
       await delay(100);
-      await write(testPath, dateNow());
+      await fsp.writeFile(testPath, dateNow());
       await waitFor([[addSpy.withArgs(testPath), 2]]);
       addSpy.should.have.been.calledWith(testPath);
       changeSpy.should.not.have.been.called;
@@ -497,10 +489,10 @@ const runTests = (baseopts) => {
       const newPath1 = dpath('moved.txt');
       const newPath2 = dpath('moved-again.txt');
       watcher.on(EV.UNLINK, unlinkSpy);
-      await fs_rename(testPath, newPath1);
+      await fsp.rename(testPath, newPath1);
 
       await delay(300);
-      await fs_rename(newPath1, newPath2);
+      await fsp.rename(newPath1, newPath2);
       await waitFor([unlinkSpy.withArgs(newPath1)]);
       unlinkSpy.withArgs(testPath).should.have.been.calledOnce;
       unlinkSpy.withArgs(newPath1).should.have.been.calledOnce;
@@ -516,8 +508,8 @@ const runTests = (baseopts) => {
       const spy = sinon.spy(function addSpy() {});
       watcher.on(EV.ADD, spy);
       spy.should.not.have.been.called;
-      await fs_mkdir(testDir, PERM);
-      await write(testPath, dateNow());
+      await fsp.mkdir(testDir, PERM);
+      await fsp.writeFile(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.been.calledOnce;
       spy.should.have.been.calledWith(testPath);
@@ -530,16 +522,16 @@ const runTests = (baseopts) => {
       const parentPath = dpath('subdir2');
       const subPath = dpath('subdir2/subsub');
       watcher.on(EV.UNLINK_DIR, unlinkSpy).on(EV.ADD_DIR, addSpy);
-      await fs_mkdir(parentPath, PERM);
+      await fsp.mkdir(parentPath, PERM);
 
       await delay(win32Polling ? 900 : 300);
-      await fs_rmdir(parentPath);
+      await fsp.rmdir(parentPath);
       await waitFor([unlinkSpy.withArgs(parentPath)]);
       unlinkSpy.should.have.been.calledWith(parentPath);
-      await fs_mkdir(parentPath, PERM);
+      await fsp.mkdir(parentPath, PERM);
 
       await delay(win32Polling ? 2200 : 1200);
-      await fs_mkdir(subPath, PERM);
+      await fsp.mkdir(subPath, PERM);
       await waitFor([[addSpy, 3]]);
       addSpy.should.have.been.calledWith(parentPath);
       addSpy.should.have.been.calledWith(subPath);
@@ -549,14 +541,14 @@ const runTests = (baseopts) => {
       const unlinkSpy = sinon.spy(function unlinkSpy() {});
       const addSpy = sinon.spy(function addSpy() {});
       const testPath = dpath('dirFile');
-      await fs_mkdir(testPath, PERM);
+      await fsp.mkdir(testPath, PERM);
       await delay(300);
       watcher.on(EV.UNLINK_DIR, unlinkSpy).on(EV.ADD, addSpy);
 
-      await fs_rmdir(testPath);
+      await fsp.rmdir(testPath);
       await waitFor([unlinkSpy]);
 
-      await write(testPath, 'file content');
+      await fsp.writeFile(testPath, 'file content');
       await waitFor([addSpy]);
 
       unlinkSpy.should.have.been.calledWith(testPath);
@@ -567,13 +559,13 @@ const runTests = (baseopts) => {
       const unlinkSpy = sinon.spy(function unlinkSpy() {});
       const addSpy = sinon.spy(function addSpy() {});
       const testPath = dpath('fileDir');
-      await write(testPath, 'file content');
+      await fsp.writeFile(testPath, 'file content');
       watcher.on(EV.UNLINK, unlinkSpy).on(EV.ADD_DIR, addSpy);
 
       await delay(300);
-      await fs_unlink(testPath);
+      await fsp.unlink(testPath);
       await delay(300);
-      await fs_mkdir(testPath, PERM);
+      await fsp.mkdir(testPath, PERM);
 
       await waitFor([addSpy, unlinkSpy]);
       unlinkSpy.should.have.been.calledWith(testPath);
@@ -600,7 +592,7 @@ const runTests = (baseopts) => {
       const testPath = dpath('change.txt');
       const watcher = cwatch(testPath, options);
       const spy = await aspy(watcher, EV.CHANGE);
-      await write(testPath, dateNow());
+      await fsp.writeFile(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.always.been.calledWith(testPath);
     });
@@ -610,7 +602,7 @@ const runTests = (baseopts) => {
       const spy = await aspy(watcher, EV.UNLINK);
 
       await delay();
-      await fs_unlink(testPath);
+      await fsp.unlink(testPath);
       await waitFor([spy]);
       spy.should.have.been.calledWith(testPath);
     });
@@ -623,12 +615,12 @@ const runTests = (baseopts) => {
       await waitForWatcher(watcher);
 
       await delay();
-      await fs_unlink(testPath);
+      await fsp.unlink(testPath);
       await waitFor([unlinkSpy]);
       unlinkSpy.should.have.been.calledWith(testPath);
 
       await delay();
-      await write(testPath, 're-added');
+      await fsp.writeFile(testPath, 're-added');
       await waitFor([addSpy]);
       addSpy.should.have.been.calledWith(testPath);
     });
@@ -640,8 +632,8 @@ const runTests = (baseopts) => {
       const spy = await aspy(watcher, EV.ALL);
 
       await delay();
-      await write(siblingPath, dateNow());
-      await write(testPath, dateNow());
+      await fsp.writeFile(siblingPath, dateNow());
+      await fsp.writeFile(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.always.been.calledWith(EV.ADD, testPath);
     });
@@ -649,19 +641,19 @@ const runTests = (baseopts) => {
     it('should detect safe-edit', async () => {
       const testPath = dpath('change.txt');
       const safePath = dpath('tmp.txt');
-      await write(testPath, dateNow());
+      await fsp.writeFile(testPath, dateNow());
       const watcher = cwatch(testPath, options);
       const spy = await aspy(watcher, EV.ALL);
 
       await delay();
-      await write(safePath, dateNow());
-      await fs_rename(safePath, testPath);
+      await fsp.writeFile(safePath, dateNow());
+      await fsp.rename(safePath, testPath);
       await delay(300);
-      await write(safePath, dateNow());
-      await fs_rename(safePath, testPath);
+      await fsp.writeFile(safePath, dateNow());
+      await fsp.rename(safePath, testPath);
       await delay(300);
-      await write(safePath, dateNow());
-      await fs_rename(safePath, testPath);
+      await fsp.writeFile(safePath, dateNow());
+      await fsp.rename(safePath, testPath);
       await delay(300);
       await waitFor([spy]);
       spy.withArgs(EV.CHANGE, testPath).should.have.been.calledThrice;
@@ -673,13 +665,13 @@ const runTests = (baseopts) => {
         const testPath = dpath('unlink.txt');
         const otherDirPath = dpath('other-dir');
         const otherPath = dpath('other-dir/other.txt');
-        await fs_mkdir(otherDirPath, PERM);
+        await fsp.mkdir(otherDirPath, PERM);
         const watcher = cwatch([testPath, otherPath], options);
         // intentionally for this test don't write write(otherPath, 'other');
         const spy = await aspy(watcher, EV.UNLINK);
 
         await delay();
-        await fs_unlink(testPath);
+        await fsp.unlink(testPath);
         await waitFor([spy]);
         spy.should.have.been.calledWith(testPath);
       });
@@ -689,21 +681,21 @@ const runTests = (baseopts) => {
         const addSpy = sinon.spy(function addSpy() {});
         const testPath = dpath('unlink.txt');
         const otherPath = dpath('other.txt');
-        await write(otherPath, 'other');
+        await fsp.writeFile(otherPath, 'other');
         const watcher = cwatch([testPath, otherPath], options)
           .on(EV.UNLINK, unlinkSpy)
           .on(EV.ADD, addSpy);
         await waitForWatcher(watcher);
 
         await delay();
-        await fs_unlink(testPath);
+        await fsp.unlink(testPath);
         await waitFor([unlinkSpy]);
 
         await delay();
         unlinkSpy.should.have.been.calledWith(testPath);
 
         await delay();
-        write(testPath, 're-added');
+        await fsp.writeFile(testPath, 're-added');
         await waitFor([addSpy]);
         addSpy.should.have.been.calledWith(testPath);
       });
@@ -714,7 +706,7 @@ const runTests = (baseopts) => {
         const testPath = dpath('unlink.txt');
         const otherDirPath = dpath('other-dir');
         const otherPath = dpath('other-dir/other.txt');
-        await fs_mkdir(otherDirPath, PERM);
+        await fsp.mkdir(otherDirPath, PERM);
         // intentionally for this test don't write write(otherPath, 'other');
         const watcher = cwatch([testPath, otherPath], options)
           .on(EV.UNLINK, unlinkSpy)
@@ -722,14 +714,14 @@ const runTests = (baseopts) => {
         await waitForWatcher(watcher);
 
         await delay();
-        await fs_unlink(testPath);
+        await fsp.unlink(testPath);
         await waitFor([unlinkSpy]);
 
         await delay();
         unlinkSpy.should.have.been.calledWith(testPath);
 
         await delay();
-        await write(testPath, 're-added');
+        await fsp.writeFile(testPath, 're-added');
         await waitFor([addSpy]);
         addSpy.should.have.been.calledWith(testPath);
       });
@@ -746,14 +738,14 @@ const runTests = (baseopts) => {
         await waitForWatcher(watcher);
 
         await delay();
-        await fs_unlink(testPath);
+        await fsp.unlink(testPath);
         await waitFor([unlinkSpy]);
 
         await delay();
         unlinkSpy.should.have.been.calledWith(testPath);
 
         await delay();
-        await write(testPath, 're-added');
+        await fsp.writeFile(testPath, 're-added');
         await waitFor([addSpy]);
         addSpy.should.have.been.calledWith(testPath);
       });
@@ -763,17 +755,17 @@ const runTests = (baseopts) => {
         const addSpy = sinon.spy(function addSpy() {});
         const testPath = dpath('unlink.txt');
         const otherPath = dpath('other.txt');
-        await write(otherPath, 'other');
+        await fsp.writeFile(otherPath, 'other');
         const watcher = cwatch([testPath, otherPath], options)
           .on(EV.UNLINK, unlinkSpy)
           .on(EV.ADD, addSpy);
         await waitForWatcher(watcher);
 
         await delay();
-        await fs_unlink(otherPath);
+        await fsp.unlink(otherPath);
 
         await delay();
-        await fs_unlink(testPath);
+        await fsp.unlink(testPath);
         await waitFor([[unlinkSpy, 2]]);
 
         await delay();
@@ -781,7 +773,7 @@ const runTests = (baseopts) => {
         unlinkSpy.should.have.been.calledWith(testPath);
 
         await delay();
-        await write(testPath, 're-added');
+        await fsp.writeFile(testPath, 're-added');
         await waitFor([addSpy]);
         addSpy.should.have.been.calledWith(testPath);
       });
@@ -792,21 +784,21 @@ const runTests = (baseopts) => {
         const testPath = dpath('unlink.txt');
         const otherPath = dpath('other.txt');
         const other2Path = dpath('other2.txt');
-        await write(otherPath, 'other');
+        await fsp.writeFile(otherPath, 'other');
         // intentionally for this test don't write write(other2Path, 'other2');
         const watcher = cwatch([testPath, otherPath, other2Path], options)
           .on(EV.UNLINK, unlinkSpy)
           .on(EV.ADD, addSpy);
         await waitForWatcher(watcher);
         await delay();
-        await fs_unlink(testPath);
+        await fsp.unlink(testPath);
 
         await waitFor([unlinkSpy]);
         await delay();
         unlinkSpy.should.have.been.calledWith(testPath);
 
         await delay();
-        await write(testPath, 're-added');
+        await fsp.writeFile(testPath, 're-added');
         await waitFor([addSpy]);
         addSpy.should.have.been.calledWith(testPath);
       });
@@ -819,13 +811,13 @@ const runTests = (baseopts) => {
       const testPath = dpath('subdir/add.txt');
       const renamedDir = dpath('subdir-renamed');
       const expectedPath = sysPath.join(renamedDir, 'add.txt');
-      await fs_mkdir(testDir, PERM);
-      await write(testPath, dateNow());
+      await fsp.mkdir(testDir, PERM);
+      await fsp.writeFile(testPath, dateNow());
       const watcher = cwatch(currentDir, options);
       const spy = await aspy(watcher, EV.ADD);
 
       await delay(1000);
-      await fs_rename(testDir, renamedDir);
+      await fsp.rename(testDir, renamedDir);
       await waitFor([spy.withArgs(expectedPath)]);
       spy.should.have.been.calledWith(expectedPath);
     });
@@ -837,7 +829,7 @@ const runTests = (baseopts) => {
       const spy = await aspy(watcher, EV.ADD);
 
       await delay();
-      await write(testPath, dateNow());
+      await fsp.writeFile(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.been.calledWith(testPath);
     });
@@ -849,9 +841,9 @@ const runTests = (baseopts) => {
       spy.should.not.have.been.called;
 
       await delay();
-      await fs_mkdir(testDir, PERM);
+      await fsp.mkdir(testDir, PERM);
       await waitFor([spy.withArgs(EV.ADD_DIR)]);
-      await write(testPath, 'hello');
+      await fsp.writeFile(testPath, 'hello');
       await waitFor([spy.withArgs(EV.ADD)]);
       spy.should.have.been.calledWith(EV.ADD_DIR, testDir);
       spy.should.have.been.calledWith(EV.ADD, testPath);
@@ -860,13 +852,13 @@ const runTests = (baseopts) => {
   describe('not watch glob patterns', () => {
     it('should not confuse glob-like filenames with globs', async () => {
       const filePath = dpath('nota[glob].txt');
-      await write(filePath, 'b');
+      await fsp.writeFile(filePath, 'b');
       await delay();
       const spy = await aspy(cwatch(currentDir, options), EV.ALL);
       spy.should.have.been.calledWith(EV.ADD, filePath);
 
       await delay();
-      await write(filePath, dateNow());
+      await fsp.writeFile(filePath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE, filePath)]);
       spy.should.have.been.calledWith(EV.CHANGE, filePath);
     });
@@ -878,11 +870,11 @@ const runTests = (baseopts) => {
       const matchingDir = dpath('notag');
       const matchingFile = dpath('notag/b.txt');
       const matchingFile2 = dpath('notal');
-      await fs_mkdir(testDir, PERM);
-      await write(filePath, 'b');
-      await fs_mkdir(matchingDir, PERM);
-      await write(matchingFile, 'c');
-      await write(matchingFile2, 'd');
+      await fsp.mkdir(testDir, PERM);
+      await fsp.writeFile(filePath, 'b');
+      await fsp.mkdir(matchingDir, PERM);
+      await fsp.writeFile(matchingFile, 'c');
+      await fsp.writeFile(matchingFile2, 'd');
       const watcher = cwatch(watchPath, options);
       const spy = await aspy(watcher, EV.ALL);
 
@@ -891,7 +883,7 @@ const runTests = (baseopts) => {
       spy.should.not.have.been.calledWith(EV.ADD, matchingFile);
       spy.should.not.have.been.calledWith(EV.ADD, matchingFile2);
       await delay();
-      await write(filePath, dateNow());
+      await fsp.writeFile(filePath, dateNow());
 
       await waitFor([spy.withArgs(EV.CHANGE, filePath)]);
       spy.should.have.been.calledWith(EV.CHANGE, filePath);
@@ -904,10 +896,10 @@ const runTests = (baseopts) => {
       const matchingDir = dpath('notag');
       const matchingFile = dpath('notag/a.txt');
       const matchingFile2 = dpath('notal');
-      await write(filePath, 'b');
-      await fs_mkdir(matchingDir, PERM);
-      await write(matchingFile, 'c');
-      await write(matchingFile2, 'd');
+      await fsp.writeFile(filePath, 'b');
+      await fsp.mkdir(matchingDir, PERM);
+      await fsp.writeFile(matchingFile, 'c');
+      await fsp.writeFile(matchingFile2, 'd');
       const watcher = cwatch(watchPath, options);
       const spy = await aspy(watcher, EV.ALL);
 
@@ -916,7 +908,7 @@ const runTests = (baseopts) => {
       spy.should.not.have.been.calledWith(EV.ADD, matchingFile);
       spy.should.not.have.been.calledWith(EV.ADD, matchingFile2);
       await delay();
-      await write(filePath, dateNow());
+      await fsp.writeFile(filePath, dateNow());
 
       await waitFor([spy.withArgs(EV.CHANGE, filePath)]);
       spy.should.have.been.calledWith(EV.CHANGE, filePath);
@@ -927,13 +919,13 @@ const runTests = (baseopts) => {
     let linkedDir;
     beforeEach(async () => {
       linkedDir = sysPath.resolve(currentDir, '..', `${testId}-link`);
-      await fs_symlink(currentDir, linkedDir, isWindows ? 'dir' : null);
-      await fs_mkdir(dpath('subdir'), PERM);
-      await write(dpath('subdir/add.txt'), 'b');
+      await fsp.symlink(currentDir, linkedDir, isWindows ? 'dir' : null);
+      await fsp.mkdir(dpath('subdir'), PERM);
+      await fsp.writeFile(dpath('subdir/add.txt'), 'b');
       return true;
     });
     afterEach(async () => {
-      await fs_unlink(linkedDir);
+      await fsp.unlink(linkedDir);
       return true;
     });
 
@@ -950,11 +942,11 @@ const runTests = (baseopts) => {
     it('should watch symlinked files', async () => {
       const changePath = dpath('change.txt');
       const linkPath = dpath('link.txt');
-      await fs_symlink(changePath, linkPath);
+      await fsp.symlink(changePath, linkPath);
       const watcher = cwatch(linkPath, options);
       const spy = await aspy(watcher, EV.ALL);
 
-      await write(changePath, dateNow());
+      await fsp.writeFile(changePath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
       spy.should.have.been.calledWith(EV.ADD, linkPath);
       spy.should.have.been.calledWith(EV.CHANGE, linkPath);
@@ -962,11 +954,11 @@ const runTests = (baseopts) => {
     it('should follow symlinked files within a normal dir', async () => {
       const changePath = dpath('change.txt');
       const linkPath = dpath('subdir/link.txt');
-      await fs_symlink(changePath, linkPath);
+      await fsp.symlink(changePath, linkPath);
       const watcher = cwatch(dpath('subdir'), options);
       const spy = await aspy(watcher, EV.ALL);
 
-      await write(changePath, dateNow());
+      await fsp.writeFile(changePath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE, linkPath)]);
       spy.should.have.been.calledWith(EV.ADD, linkPath);
       spy.should.have.been.calledWith(EV.CHANGE, linkPath);
@@ -979,12 +971,12 @@ const runTests = (baseopts) => {
 
       spy.should.have.been.calledWith(EV.ADD_DIR, testDir);
       spy.should.have.been.calledWith(EV.ADD, testFile);
-      await write(dpath('subdir/add.txt'), dateNow());
+      await fsp.writeFile(dpath('subdir/add.txt'), dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
       spy.should.have.been.calledWith(EV.CHANGE, testFile);
     });
     it('should not recurse indefinitely on circular symlinks', async () => {
-      await fs_symlink(currentDir, dpath('subdir/circular'), isWindows ? 'dir' : null);
+      await fsp.symlink(currentDir, dpath('subdir/circular'), isWindows ? 'dir' : null);
       return new Promise((resolve, reject) => {
         const watcher = cwatch(currentDir, options);
         watcher.on(EV.ERROR, resolve());
@@ -999,7 +991,7 @@ const runTests = (baseopts) => {
       const watcher = cwatch(linkedDir, options);
       const spy = await aspy(watcher, EV.CHANGE);
       const wa = spy.withArgs(linkedFilePath);
-      await write(dpath('change.txt'), dateNow());
+      await fsp.writeFile(dpath('change.txt'), dateNow());
       await waitFor([wa]);
       spy.should.have.been.calledWith(linkedFilePath);
     });
@@ -1008,7 +1000,7 @@ const runTests = (baseopts) => {
       const watcher = cwatch(currentDir, options);
       const spy = await aspy(watcher, EV.ALL);
       await delay();
-      await fs_symlink(dpath('subdir'), dpath('link'), isWindows ? 'dir' : null);
+      await fsp.symlink(dpath('subdir'), dpath('link'), isWindows ? 'dir' : null);
       await waitFor([
         spy.withArgs(EV.ADD, dpath('link/add.txt')),
         spy.withArgs(EV.ADD_DIR, dpath('link')),
@@ -1027,9 +1019,9 @@ const runTests = (baseopts) => {
     it('should survive ENOENT for missing symlinks when followSymlinks:false', async () => {
       options.followSymlinks = false;
       const targetDir = dpath('subdir/nonexistent');
-      await fs_mkdir(targetDir);
-      await fs_symlink(targetDir, dpath('subdir/broken'), isWindows ? 'dir' : null);
-      await fs_rmdir(targetDir);
+      await fsp.mkdir(targetDir);
+      await fsp.symlink(targetDir, dpath('subdir/broken'), isWindows ? 'dir' : null);
+      await fsp.rmdir(targetDir);
       await delay();
 
       const watcher = cwatch(dpath('subdir'), options);
@@ -1043,7 +1035,7 @@ const runTests = (baseopts) => {
       options.followSymlinks = false;
       // Create symlink in linkPath
       const linkPath = dpath('link');
-      await fs_symlink(dpath('subdir'), linkPath);
+      await fsp.symlink(dpath('subdir'), linkPath);
       const spy = await aspy(cwatch(currentDir, options), EV.ALL);
       await delay(300);
       setTimeout(
@@ -1066,9 +1058,9 @@ const runTests = (baseopts) => {
       const linkedPath = dpath('outside');
       const linkedFilePath = sysPath.join(linkedPath, 'text.txt');
       const linkPath = dpath('subdir/subsub');
-      await fs_mkdir(linkedPath, PERM);
-      await write(linkedFilePath, 'b');
-      await fs_symlink(linkedPath, linkPath);
+      await fsp.mkdir(linkedPath, PERM);
+      await fsp.writeFile(linkedFilePath, 'b');
+      await fsp.symlink(linkedPath, linkPath);
       const watcher2 = cwatch(dpath('subdir'), options);
       await waitForWatcher(watcher2);
 
@@ -1078,15 +1070,15 @@ const runTests = (baseopts) => {
       const spy = await aspy(watcher, EV.ALL);
 
       await delay();
-      await write(linkedFilePath, dateNow());
+      await fsp.writeFile(linkedFilePath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
       spy.should.have.been.calledWith(EV.CHANGE, watchedPath);
     });
     it('should emit ready event even when broken symlinks are encountered', async () => {
       const targetDir = dpath('subdir/nonexistent');
-      await fs_mkdir(targetDir);
-      await fs_symlink(targetDir, dpath('subdir/broken'), isWindows ? 'dir' : null);
-      await fs_rmdir(targetDir);
+      await fsp.mkdir(targetDir);
+      await fsp.symlink(targetDir, dpath('subdir/broken'), isWindows ? 'dir' : null);
+      await fsp.rmdir(targetDir);
       const readySpy = sinon.spy(function readySpy() {});
       const watcher = cwatch(dpath('subdir'), options).on(EV.READY, readySpy);
       await waitForWatcher(watcher);
@@ -1097,26 +1089,26 @@ const runTests = (baseopts) => {
     it('should watch all paths in an array', async () => {
       const testPath = dpath('change.txt');
       const testDir = dpath('subdir');
-      await fs_mkdir(testDir);
+      await fsp.mkdir(testDir);
       const watcher = cwatch([testDir, testPath], options);
       const spy = await aspy(watcher, EV.ALL);
       spy.should.have.been.calledWith(EV.ADD, testPath);
       spy.should.have.been.calledWith(EV.ADD_DIR, testDir);
       spy.should.not.have.been.calledWith(EV.ADD, dpath('unlink.txt'));
-      await write(testPath, dateNow());
+      await fsp.writeFile(testPath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
       spy.should.have.been.calledWith(EV.CHANGE, testPath);
     });
     it('should accommodate nested arrays in input', async () => {
       const testPath = dpath('change.txt');
       const testDir = dpath('subdir');
-      await fs_mkdir(testDir);
+      await fsp.mkdir(testDir);
       const watcher = cwatch([[testDir], [testPath]], options);
       const spy = await aspy(watcher, EV.ALL);
       spy.should.have.been.calledWith(EV.ADD, testPath);
       spy.should.have.been.calledWith(EV.ADD_DIR, testDir);
       spy.should.not.have.been.calledWith(EV.ADD, dpath('unlink.txt'));
-      await write(testPath, dateNow());
+      await fsp.writeFile(testPath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
       spy.should.have.been.calledWith(EV.CHANGE, testPath);
     });
@@ -1145,8 +1137,8 @@ const runTests = (baseopts) => {
           spy.should.have.been.calledWith(currentDir);
         });
         it('should emit `addDir` events for preexisting dirs', async () => {
-          await fs_mkdir(dpath('subdir'), PERM);
-          await fs_mkdir(dpath('subdir/subsub'), PERM);
+          await fsp.mkdir(dpath('subdir'), PERM);
+          await fsp.mkdir(dpath('subdir/subsub'), PERM);
           const watcher = cwatch(currentDir, options);
           const spy = await aspy(watcher, EV.ADD_DIR);
           spy.should.have.been.calledWith(currentDir);
@@ -1177,8 +1169,8 @@ const runTests = (baseopts) => {
           const testPath = dpath('subdir/add.txt');
           const spy = await aspy(cwatch(currentDir, options), EV.ADD);
           spy.should.not.have.been.called;
-          await fs_mkdir(testDir, PERM);
-          await write(testPath, dateNow());
+          await fsp.mkdir(testDir, PERM);
+          await fsp.writeFile(testPath, dateNow());
           await waitFor([spy]);
           spy.should.have.been.calledOnce;
           spy.should.have.been.calledWith(testPath);
@@ -1187,7 +1179,7 @@ const runTests = (baseopts) => {
           const testPath = dpath('change.txt');
           const spy = await aspy(cwatch(currentDir, options), EV.ALL);
           spy.should.not.have.been.called;
-          await write(testPath, dateNow());
+          await fsp.writeFile(testPath, dateNow());
           await waitFor([spy.withArgs(EV.CHANGE, testPath)]);
           spy.should.have.been.calledWith(EV.CHANGE, testPath);
           spy.should.not.have.been.calledWith(EV.ADD);
@@ -1195,11 +1187,11 @@ const runTests = (baseopts) => {
         it('should not emit for preexisting dirs when depth is 0', async () => {
           options.depth = 0;
           const testPath = dpath('add.txt');
-          await fs_mkdir(dpath('subdir'), PERM);
+          await fsp.mkdir(dpath('subdir'), PERM);
 
           await delay(200);
           const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-          await write(testPath, dateNow());
+          await fsp.writeFile(testPath, dateNow());
           await waitFor([spy]);
 
           await delay(200);
@@ -1215,10 +1207,10 @@ const runTests = (baseopts) => {
           return stats.isDirectory();
         };
         const testDir = dpath('subdir');
-        await fs_mkdir(testDir, PERM);
-        await write(sysPath.join(testDir, 'add.txt'), '');
-        await fs_mkdir(sysPath.join(testDir, 'subsub'), PERM);
-        await write(sysPath.join(testDir, 'subsub', 'ab.txt'), '');
+        await fsp.mkdir(testDir, PERM);
+        await fsp.writeFile(sysPath.join(testDir, 'add.txt'), '');
+        await fsp.mkdir(sysPath.join(testDir, 'subsub'), PERM);
+        await fsp.writeFile(sysPath.join(testDir, 'subsub', 'ab.txt'), '');
         const watcher = cwatch(testDir, options);
         const spy = await aspy(watcher, EV.ADD);
         spy.should.have.been.calledOnce;
@@ -1234,13 +1226,13 @@ const runTests = (baseopts) => {
         const testDir = dpath('subdir');
         const testFile = sysPath.join(testDir, 'add.txt');
         options.ignored = testDir;
-        await fs_mkdir(testDir, PERM);
-        await write(testFile, 'b');
+        await fsp.mkdir(testDir, PERM);
+        await fsp.writeFile(testFile, 'b');
         const watcher = cwatch(currentDir, options);
         const spy = await aspy(watcher, EV.ALL);
 
         await delay();
-        await write(testFile, dateNow());
+        await fsp.writeFile(testFile, dateNow());
 
         await delay(300);
         spy.should.not.have.been.calledWith(EV.ADD_DIR, testDir);
@@ -1251,13 +1243,13 @@ const runTests = (baseopts) => {
         options.cwd = currentDir;
         options.ignored = /add/;
 
-        await write(dpath('add.txt'), 'b');
+        await fsp.writeFile(dpath('add.txt'), 'b');
         const watcher = cwatch(currentDir, options);
         const spy = await aspy(watcher, EV.ALL);
 
         await delay();
-        await write(dpath('add.txt'), dateNow());
-        await write(dpath('change.txt'), dateNow());
+        await fsp.writeFile(dpath('add.txt'), dateNow());
+        await fsp.writeFile(dpath('change.txt'), dateNow());
 
         await waitFor([spy.withArgs(EV.CHANGE, 'change.txt')]);
         spy.should.not.have.been.calledWith(EV.ADD, 'add.txt');
@@ -1268,18 +1260,18 @@ const runTests = (baseopts) => {
     });
     describe('depth', () => {
       beforeEach(async () => {
-        await fs_mkdir(dpath('subdir'), PERM);
-        await write(dpath('subdir/add.txt'), 'b');
+        await fsp.mkdir(dpath('subdir'), PERM);
+        await fsp.writeFile(dpath('subdir/add.txt'), 'b');
         await delay();
-        await fs_mkdir(dpath('subdir/subsub'), PERM);
-        await write(dpath('subdir/subsub/ab.txt'), 'b');
+        await fsp.mkdir(dpath('subdir/subsub'), PERM);
+        await fsp.writeFile(dpath('subdir/subsub/ab.txt'), 'b');
         await delay();
       });
       it('should not recurse if depth is 0', async () => {
         options.depth = 0;
         const watcher = cwatch(currentDir, options);
         const spy = await aspy(watcher, EV.ALL);
-        await write(dpath('subdir/add.txt'), dateNow());
+        await fsp.writeFile(dpath('subdir/add.txt'), dateNow());
         await waitFor([[spy, 4]]);
         spy.should.have.been.calledWith(EV.ADD_DIR, currentDir);
         spy.should.have.been.calledWith(EV.ADD_DIR, dpath('subdir'));
@@ -1295,9 +1287,9 @@ const runTests = (baseopts) => {
         const ignoredPath = dpath('subdir/subsub/ab.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
         await delay();
-        await write(dpath('change.txt'), dateNow());
-        await write(addPath, dateNow());
-        await write(ignoredPath, dateNow());
+        await fsp.writeFile(dpath('change.txt'), dateNow());
+        await fsp.writeFile(addPath, dateNow());
+        await fsp.writeFile(ignoredPath, dateNow());
         await waitFor([spy.withArgs(EV.CHANGE, addPath), spy.withArgs(EV.CHANGE, changePath)]);
         spy.should.have.been.calledWith(EV.ADD_DIR, dpath('subdir/subsub'));
         spy.should.have.been.calledWith(EV.CHANGE, changePath);
@@ -1309,7 +1301,7 @@ const runTests = (baseopts) => {
       it('should respect depth setting when following symlinks', async () => {
         if (isWindows) return true; // skip on windows
         options.depth = 1;
-        await fs_symlink(dpath('subdir'), dpath('link'), isWindows ? 'dir' : null);
+        await fsp.symlink(dpath('subdir'), dpath('link'), isWindows ? 'dir' : null);
         await delay();
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
         spy.should.have.been.calledWith(EV.ADD_DIR, dpath('link'));
@@ -1324,7 +1316,7 @@ const runTests = (baseopts) => {
         const linkPath = dpath('link');
         const dirPath = dpath('link/subsub');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await fs_symlink(dpath('subdir'), linkPath, isWindows ? 'dir' : null);
+        await fsp.symlink(dpath('subdir'), linkPath, isWindows ? 'dir' : null);
         await waitFor([[spy, 3], spy.withArgs(EV.ADD_DIR, dirPath)]);
         spy.should.have.been.calledWith(EV.ADD_DIR, linkPath);
         spy.should.have.been.calledWith(EV.ADD_DIR, dirPath);
@@ -1339,11 +1331,11 @@ const runTests = (baseopts) => {
         const unlinkSpy = spy.withArgs(EV.UNLINK_DIR);
         spy.should.have.been.calledWith(EV.ADD_DIR, currentDir);
         spy.should.have.been.calledWith(EV.ADD_DIR, dpath('subdir'));
-        await fs_mkdir(subdir2, PERM);
+        await fsp.mkdir(subdir2, PERM);
         await waitFor([[addSpy, 3]]);
         addSpy.should.have.been.calledThrice;
 
-        await fs_rmdir(subdir2);
+        await fsp.rmdir(subdir2);
         await waitFor([unlinkSpy]);
         await delay();
         unlinkSpy.should.have.been.calledWith(EV.UNLINK_DIR, subdir2);
@@ -1357,23 +1349,23 @@ const runTests = (baseopts) => {
       });
       it('should ignore vim/emacs/Sublime swapfiles', async () => {
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await write(dpath('.change.txt.swp'), 'a'); // vim
-        await write(dpath('add.txt~'), 'a'); // vim/emacs
-        await write(dpath('.subl5f4.tmp'), 'a'); // sublime
+        await fsp.writeFile(dpath('.change.txt.swp'), 'a'); // vim
+        await fsp.writeFile(dpath('add.txt~'), 'a'); // vim/emacs
+        await fsp.writeFile(dpath('.subl5f4.tmp'), 'a'); // sublime
         await delay(300);
-        await write(dpath('.change.txt.swp'), 'c');
-        await write(dpath('add.txt~'), 'c');
-        await write(dpath('.subl5f4.tmp'), 'c');
+        await fsp.writeFile(dpath('.change.txt.swp'), 'c');
+        await fsp.writeFile(dpath('add.txt~'), 'c');
+        await fsp.writeFile(dpath('.subl5f4.tmp'), 'c');
         await delay(300);
-        await fs_unlink(dpath('.change.txt.swp'));
-        await fs_unlink(dpath('add.txt~'));
-        await fs_unlink(dpath('.subl5f4.tmp'));
+        await fsp.unlink(dpath('.change.txt.swp'));
+        await fsp.unlink(dpath('add.txt~'));
+        await fsp.unlink(dpath('.subl5f4.tmp'));
         await delay(300);
         spy.should.not.have.been.called;
       });
       it('should ignore stale tilde files', async () => {
         options.ignoreInitial = false;
-        await write(dpath('old.txt~'), 'a');
+        await fsp.writeFile(dpath('old.txt~'), 'a');
         await delay();
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
         spy.should.not.have.been.calledWith(dpath('old.txt'));
@@ -1385,8 +1377,8 @@ const runTests = (baseopts) => {
         options.cwd = currentDir;
         const watcher = cwatch('.', options);
         const spy = await aspy(watcher, EV.ALL);
-        await fs_unlink(dpath('unlink.txt'));
-        await write(dpath('change.txt'), dateNow());
+        await fsp.unlink(dpath('unlink.txt'));
+        await fsp.writeFile(dpath('change.txt'), dateNow());
         await waitFor([spy.withArgs(EV.UNLINK)]);
         spy.should.have.been.calledWith(EV.ADD, 'change.txt');
         spy.should.have.been.calledWith(EV.ADD, 'unlink.txt');
@@ -1401,13 +1393,13 @@ const runTests = (baseopts) => {
         const testDir = dpath('subdir');
         const renamedDir = dpath('subdir-renamed');
 
-        await fs_mkdir(testDir, PERM);
+        await fsp.mkdir(testDir, PERM);
         const watcher = cwatch('.', options);
 
         await new Promise((resolve) => {
-          setTimeout(() => {
+          setTimeout(async () => {
             watcher.on(EV.ADD_DIR, spy);
-            fs_rename(testDir, renamedDir);
+            await fsp.rename(testDir, renamedDir);
             resolve();
           }, 1000);
         });
@@ -1433,8 +1425,8 @@ const runTests = (baseopts) => {
         const watcher2Events = waitForEvents(watcher2, 5);
         const spy2 = await aspy(watcher2, EV.ALL);
 
-        await fs_unlink(dpath('unlink.txt'));
-        await write(dpath('change.txt'), dateNow());
+        await fsp.unlink(dpath('unlink.txt'));
+        await fsp.writeFile(dpath('change.txt'), dateNow());
         await Promise.all([watcherEvents, watcher2Events]);
         spy1.should.have.been.calledWith(EV.CHANGE, 'change.txt');
         spy1.should.have.been.calledWith(EV.UNLINK, 'unlink.txt');
@@ -1447,18 +1439,18 @@ const runTests = (baseopts) => {
         options.cwd = currentDir;
         options.ignored = ['ignored-option.txt', 'ignored.txt'];
         const files = ['.'];
-        await write(dpath('change.txt'), 'hello');
-        await write(dpath('ignored.txt'), 'ignored');
-        await write(dpath('ignored-option.txt'), 'ignored option');
+        await fsp.writeFile(dpath('change.txt'), 'hello');
+        await fsp.writeFile(dpath('ignored.txt'), 'ignored');
+        await fsp.writeFile(dpath('ignored-option.txt'), 'ignored option');
         const watcher = cwatch(files, options);
 
         const spy = await aspy(watcher, EV.ALL);
-        await write(dpath('ignored.txt'), dateNow());
-        await write(dpath('ignored-option.txt'), dateNow());
-        await fs_unlink(dpath('ignored.txt'));
-        await fs_unlink(dpath('ignored-option.txt'));
+        await fsp.writeFile(dpath('ignored.txt'), dateNow());
+        await fsp.writeFile(dpath('ignored-option.txt'), dateNow());
+        await fsp.unlink(dpath('ignored.txt'));
+        await fsp.unlink(dpath('ignored-option.txt'));
         await delay();
-        await write(dpath('change.txt'), EV.CHANGE);
+        await fsp.writeFile(dpath('change.txt'), EV.CHANGE);
         await waitFor([spy.withArgs(EV.CHANGE, 'change.txt')]);
         spy.should.have.been.calledWith(EV.ADD, 'change.txt');
         spy.should.not.have.been.calledWith(EV.ADD, 'ignored.txt');
@@ -1474,7 +1466,7 @@ const runTests = (baseopts) => {
       let filePath;
       beforeEach(async () => {
         filePath = dpath('add.txt');
-        await write(filePath, 'b', { mode: 128 });
+        await fsp.writeFile(filePath, 'b', { mode: 128 });
         await delay();
       });
       describe('false', () => {
@@ -1486,7 +1478,7 @@ const runTests = (baseopts) => {
           if (isWindows) return true;
           const spy = await aspy(cwatch(currentDir, options), EV.ALL);
           spy.should.not.have.been.calledWith(EV.ADD, filePath);
-          await write(filePath, dateNow());
+          await fsp.writeFile(filePath, dateNow());
 
           await delay(200);
           spy.should.not.have.been.calledWith(EV.CHANGE, filePath);
@@ -1520,14 +1512,14 @@ const runTests = (baseopts) => {
       it('should not emit add event before a file is fully written', async () => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await write(testPath, 'hello');
+        await fsp.writeFile(testPath, 'hello');
         await delay(200);
         spy.should.not.have.been.calledWith(EV.ADD);
       });
       it('should wait for the file to be fully written before emitting the add event', async () => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await write(testPath, 'hello');
+        await fsp.writeFile(testPath, 'hello');
 
         await delay(300);
         spy.should.not.have.been.called;
@@ -1537,7 +1529,7 @@ const runTests = (baseopts) => {
       it('should emit with the final stats', async () => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await write(testPath, 'hello ');
+        await fsp.writeFile(testPath, 'hello ');
 
         await delay(300);
         fs.appendFileSync(testPath, 'world!');
@@ -1549,16 +1541,16 @@ const runTests = (baseopts) => {
       it('should not emit change event while a file has not been fully written', async () => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await write(testPath, 'hello');
+        await fsp.writeFile(testPath, 'hello');
         await delay(100);
-        await write(testPath, 'edit');
+        await fsp.writeFile(testPath, 'edit');
         await delay(200);
         spy.should.not.have.been.calledWith(EV.CHANGE, testPath);
       });
       it('should not emit change event before an existing file is fully updated', async () => {
         const testPath = dpath('change.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await write(testPath, 'hello');
+        await fsp.writeFile(testPath, 'hello');
         await delay(300);
         spy.should.not.have.been.calledWith(EV.CHANGE, testPath);
       });
@@ -1576,20 +1568,20 @@ const runTests = (baseopts) => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
         await delay();
-        await write(testPath, 'hello');
+        await fsp.writeFile(testPath, 'hello');
 
         await waitFor([spy]);
         spy.should.have.been.calledWith(EV.ADD, testPath);
-        await write(testPath, 'edit');
+        await fsp.writeFile(testPath, 'edit');
         await waitFor([spy.withArgs(EV.CHANGE)]);
         spy.should.have.been.calledWith(EV.CHANGE, testPath);
       });
       it('should not raise any event for a file that was deleted before fully written', async () => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await write(testPath, 'hello');
+        await fsp.writeFile(testPath, 'hello');
         await delay(400);
-        await fs_unlink(testPath);
+        await fsp.unlink(testPath);
         await delay(400);
         spy.should.not.have.been.calledWith(sinon.match.string, testPath);
       });
@@ -1597,13 +1589,13 @@ const runTests = (baseopts) => {
         const testPath = dpath('subdir/add.txt');
         const filename = sysPath.basename(testPath);
         options.cwd = sysPath.dirname(testPath);
-        await fs_mkdir(options.cwd);
+        await fsp.mkdir(options.cwd);
 
         await delay(200);
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
 
         await delay(400);
-        await write(testPath, 'hello');
+        await fsp.writeFile(testPath, 'hello');
 
         await waitFor([spy.withArgs(EV.ADD)]);
         spy.should.have.been.calledWith(EV.ADD, filename);
@@ -1618,14 +1610,14 @@ const runTests = (baseopts) => {
         const testPath = dpath('subdir/add.txt');
         const filename = sysPath.basename(testPath);
         options.cwd = sysPath.dirname(testPath);
-        await fs_mkdir(options.cwd);
+        await fsp.mkdir(options.cwd);
         await delay();
-        await write(testPath, 'hello');
+        await fsp.writeFile(testPath, 'hello');
         await delay();
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await write(testPath, 'edit');
+        await fsp.writeFile(testPath, 'edit');
         await delay();
-        await fs_unlink(testPath);
+        await fsp.unlink(testPath);
         await waitFor([spy.withArgs(EV.UNLINK)]);
         spy.should.have.been.calledWith(EV.UNLINK, filename);
         spy.should.not.have.been.calledWith(EV.CHANGE, filename);
@@ -1729,7 +1721,7 @@ const runTests = (baseopts) => {
         '..': [testId.toString()],
         subdir: [],
       };
-      await fs_mkdir(dpath('subdir'), PERM);
+      await fsp.mkdir(dpath('subdir'), PERM);
       const watcher = cwatch(currentDir, options);
       await waitForWatcher(watcher);
       expect(watcher.getWatched()).to.deep.equal(expected);
@@ -1738,7 +1730,7 @@ const runTests = (baseopts) => {
   describe('unwatch', () => {
     beforeEach(async () => {
       options.ignoreInitial = true;
-      await fs_mkdir(dpath('subdir'), PERM);
+      await fsp.mkdir(dpath('subdir'), PERM);
       await delay();
     });
     it('should stop watching unwatched paths', async () => {
@@ -1748,8 +1740,8 @@ const runTests = (baseopts) => {
       watcher.unwatch(dpath('subdir'));
 
       await delay();
-      await write(dpath('subdir/add.txt'), dateNow());
-      await write(dpath('change.txt'), dateNow());
+      await fsp.writeFile(dpath('subdir/add.txt'), dateNow());
+      await fsp.writeFile(dpath('change.txt'), dateNow());
       await waitFor([spy]);
 
       await delay(300);
@@ -1769,9 +1761,9 @@ const runTests = (baseopts) => {
       watcher.unwatch([subdirRel, gpath('unlink.txt')]);
 
       await delay();
-      await fs_unlink(unlinkFile);
-      await write(addFile, dateNow());
-      await write(changedFile, dateNow());
+      await fsp.unlink(unlinkFile);
+      await fsp.writeFile(addFile, dateNow());
+      await fsp.writeFile(changedFile, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
 
       await delay(300);
@@ -1790,8 +1782,8 @@ const runTests = (baseopts) => {
 
       await delay();
       watcher.unwatch(subdir);
-      await write(dpath('subdir/add.txt'), dateNow());
-      await write(dpath('change.txt'), dateNow());
+      await fsp.writeFile(dpath('subdir/add.txt'), dateNow());
+      await fsp.writeFile(dpath('change.txt'), dateNow());
       await waitFor([spy]);
 
       await delay(300);
@@ -1811,7 +1803,7 @@ const runTests = (baseopts) => {
       watcher.on(EV.ALL, spy).add(dpath('change.txt'));
 
       await delay();
-      await write(dpath('change.txt'), dateNow());
+      await fsp.writeFile(dpath('change.txt'), dateNow());
       console.log('a');
       await waitFor([spy]);
       console.log('b');
@@ -1825,9 +1817,9 @@ const runTests = (baseopts) => {
       watcher.unwatch(['subdir', dpath('unlink.txt')]);
 
       await delay();
-      await fs_unlink(dpath('unlink.txt'));
-      await write(dpath('subdir/add.txt'), dateNow());
-      await write(dpath('change.txt'), dateNow());
+      await fsp.unlink(dpath('unlink.txt'));
+      await fsp.writeFile(dpath('subdir/add.txt'), dateNow());
+      await fsp.writeFile(dpath('change.txt'), dateNow());
       await waitFor([spy]);
 
       await delay(300);
@@ -1909,9 +1901,9 @@ const runTests = (baseopts) => {
       const fixturesPathRel = sysPath.join(CURR, 'test-case-1040');
       const linkPath = sysPath.join(fixturesPathRel, 'symlinkFolder');
       const packagesPath = sysPath.join(fixturesPathRel, 'packages');
-      await fs_mkdir(fixturesPathRel, { recursive: true });
-      await fs_mkdir(linkPath);
-      await fs_mkdir(packagesPath);
+      await fsp.mkdir(fixturesPathRel, { recursive: true });
+      await fsp.mkdir(linkPath);
+      await fsp.mkdir(packagesPath);
 
       // Init chokidar
       const watcher = cwatch([]);
@@ -1919,11 +1911,11 @@ const runTests = (baseopts) => {
       // Add more than 10 folders to cap consolidateThreshhold
       for (let i = 0; i < 20; i += 1) {
         const folderPath = sysPath.join(packagesPath, `folder${i}`);
-        await fs_mkdir(folderPath);
+        await fsp.mkdir(folderPath);
         const filePath = sysPath.join(folderPath, `file${i}.js`);
-        await write(sysPath.resolve(filePath), 'file content');
+        await fsp.writeFile(sysPath.resolve(filePath), 'file content');
         const symlinkPath = sysPath.join(linkPath, `folder${i}`);
-        await fs_symlink(sysPath.resolve(folderPath), symlinkPath, isWindows ? 'dir' : null);
+        await fsp.symlink(sysPath.resolve(folderPath), symlinkPath, isWindows ? 'dir' : null);
         watcher.add(sysPath.resolve(sysPath.join(symlinkPath, `file${i}.js`)));
       }
 
@@ -1934,7 +1926,7 @@ const runTests = (baseopts) => {
 
       // Update a random generated file to fire an event
       const randomFilePath = sysPath.join(packagesPath, 'folder17', 'file17.js');
-      await write(sysPath.resolve(randomFilePath), 'file content changer zeri ezhriez');
+      await fsp.writeFile(sysPath.resolve(randomFilePath), 'file content changer zeri ezhriez');
 
       // Wait chokidar watch
       await delay(300);
@@ -1959,16 +1951,16 @@ const runTests = (baseopts) => {
 
         // Command sequence from https://github.com/paulmillr/chokidar/issues/1042.
         await delay();
-        await fs_mkdir(absoluteWatchedDir);
-        await fs_mkdir(testSubDir);
+        await fsp.mkdir(absoluteWatchedDir);
+        await fsp.mkdir(testSubDir);
         // The following delay is essential otherwise the call of mkdir and rmdir will be equalize
         await delay(300);
-        await fs_rmdir(testSubDir);
+        await fsp.rmdir(testSubDir);
         // The following delay is essential otherwise the call of rmdir and mkdir will be equalize
         await delay(300);
-        await fs_mkdir(testSubDir);
+        await fsp.mkdir(testSubDir);
         await delay(300);
-        await write(testSubDirFile, '');
+        await fsp.writeFile(testSubDirFile, '');
         await delay(300);
 
         const events = await eventsWaiter;
@@ -1989,7 +1981,7 @@ const runTests = (baseopts) => {
       const id = testId.toString();
       const relativeWatcherDir = sysPath.join(id, 'test');
       const linkedRelativeWatcherDir = sysPath.join(id, 'test-link');
-      await fs_symlink(
+      await fsp.symlink(
         sysPath.resolve(relativeWatcherDir),
         linkedRelativeWatcherDir,
         isWindows ? 'dir' : null
@@ -2005,16 +1997,16 @@ const runTests = (baseopts) => {
 
         // Command sequence from https://github.com/paulmillr/chokidar/issues/1042.
         await delay();
-        await fs_mkdir(relativeWatcherDir);
-        await fs_mkdir(testSubDir);
+        await fsp.mkdir(relativeWatcherDir);
+        await fsp.mkdir(testSubDir);
         // The following delay is essential otherwise the call of mkdir and rmdir will be equalize
         await delay(300);
-        await fs_rmdir(testSubDir);
+        await fsp.rmdir(testSubDir);
         // The following delay is essential otherwise the call of rmdir and mkdir will be equalize
         await delay(300);
-        await fs_mkdir(testSubDir);
+        await fsp.mkdir(testSubDir);
         await delay(300);
-        await write(testSubDirFile, '');
+        await fsp.writeFile(testSubDirFile, '');
         await delay(300);
 
         const events = await eventsWaiter;
@@ -2041,10 +2033,10 @@ const runTests = (baseopts) => {
       watcher.on(EV.ALL, spy);
       await watcher.close();
 
-      await write(dpath('add.txt'), dateNow());
-      await write(dpath('add.txt'), 'hello');
+      await fsp.writeFile(dpath('add.txt'), dateNow());
+      await fsp.writeFile(dpath('add.txt'), 'hello');
       await delay(300);
-      await fs_unlink(dpath('add.txt'));
+      await fsp.unlink(dpath('add.txt'));
 
       spy.should.not.have.been.called;
     });
@@ -2058,10 +2050,10 @@ const runTests = (baseopts) => {
       watcher2.on(EV.ADD, spy);
       await watcher1.close();
 
-      await write(dpath('add.txt'), 'hello');
+      await fsp.writeFile(dpath('add.txt'), 'hello');
       // Ensures EV_ADD is called. Immediately removing the file causes it to be skipped
       await delay(200);
-      await fs_unlink(dpath('add.txt'));
+      await fsp.unlink(dpath('add.txt'));
 
       spy.should.have.been.calledWith(sinon.match('add.txt'));
     });
@@ -2080,7 +2072,7 @@ const runTests = (baseopts) => {
           process.stdout.write("closed");
         });
       })();`;
-      await write(scriptFile, scriptContent);
+      await fsp.writeFile(scriptFile, scriptContent);
       const obj = await exec(`node ${scriptFile}`);
       const { stdout } = obj;
       expect(stdout.toString()).to.equal('closed');
@@ -2104,7 +2096,7 @@ describe('chokidar', async () => {
   afterEach(async () => {
     const promises = WATCHERS.map((w) => w.close());
     await Promise.all(promises);
-    await rm(currentDir, { recursive: true });
+    await fsp.rm(currentDir, { recursive: true });
   });
 
   it('should expose public API methods', () => {
@@ -2119,27 +2111,27 @@ describe('chokidar', async () => {
 });
 async function main() {
   try {
-    await rm(FIXTURES_PATH, { recursive: true, force: true });
-    await fs_mkdir(FIXTURES_PATH, { recursive: true, mode: PERM });
+    await fsp.rm(FIXTURES_PATH, { recursive: true, force: true });
+    await fsp.mkdir(FIXTURES_PATH, { recursive: true, mode: PERM });
   } catch (error) {}
   process.chdir(FIXTURES_PATH);
   // Create many directories before tests.
   // Creating them in `beforeEach` increases chance of random failures.
-  const _content = await read(__filename, 'utf-8');
+  const _content = await fsp.readFile(__filename, 'utf-8');
   const _only = _content.match(/\sit\.only\(/g);
   const itCount = (_only && _only.length) || _content.match(/\sit\(/g).length;
   const testCount = itCount * 3;
   while (testId++ < testCount) {
-    await fs_mkdir(dpath(''), PERM);
-    await write(dpath('change.txt'), 'b');
-    await write(dpath('unlink.txt'), 'b');
+    await fsp.mkdir(dpath(''), PERM);
+    await fsp.writeFile(dpath('change.txt'), 'b');
+    await fsp.writeFile(dpath('unlink.txt'), 'b');
   }
   testId = 0;
 
   await it.run(true);
 
   try {
-    await rm(FIXTURES_PATH, { recursive: true, force: true });
+    await fsp.rm(FIXTURES_PATH, { recursive: true, force: true });
   } catch (error) {}
   process.chdir(initialPath);
 }

--- a/test.mjs
+++ b/test.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs'; // fs.stat is mocked below, so can't import INDIVIDUAL methods
 import * as fsp from 'node:fs/promises';
+import { writeFile as write, readFile as read, rm } from 'node:fs/promises';
 import sysPath from 'node:path';
 import { describe, it, beforeEach, afterEach } from 'micro-should';
 import { fileURLToPath, pathToFileURL, URL } from 'node:url';
@@ -197,7 +198,7 @@ const runTests = (baseopts) => {
       const spy = sinon.spy(function addSpy() {});
       watcher.on(EV.ADD, spy);
       await delay();
-      await fsp.writeFile(testPath, dateNow());
+      await write(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.been.calledOnce;
       spy.should.have.been.calledWith(testPath);
@@ -215,19 +216,19 @@ const runTests = (baseopts) => {
         spy(path);
       });
 
-      await fsp.writeFile(paths[0], dateNow());
-      await fsp.writeFile(paths[1], dateNow());
-      await fsp.writeFile(paths[2], dateNow());
-      await fsp.writeFile(paths[3], dateNow());
-      await fsp.writeFile(paths[4], dateNow());
+      await write(paths[0], dateNow());
+      await write(paths[1], dateNow());
+      await write(paths[2], dateNow());
+      await write(paths[3], dateNow());
+      await write(paths[4], dateNow());
       await delay(100);
 
-      await fsp.writeFile(paths[5], dateNow());
-      await fsp.writeFile(paths[6], dateNow());
+      await write(paths[5], dateNow());
+      await write(paths[6], dateNow());
 
       await delay(150);
-      await fsp.writeFile(paths[7], dateNow());
-      await fsp.writeFile(paths[8], dateNow());
+      await write(paths[7], dateNow());
+      await write(paths[8], dateNow());
 
       await waitFor([[spy, 4]]);
 
@@ -327,7 +328,7 @@ const runTests = (baseopts) => {
       let currentCallCount = 0;
 
       for (const fileToWrite of filesToWrite) {
-        await fsp.writeFile(fileToWrite, dateNow());
+        await write(fileToWrite, dateNow());
         await waitFor([[spy, ++currentCallCount]]);
       }
 
@@ -382,7 +383,7 @@ const runTests = (baseopts) => {
       const spy = sinon.spy(function changeSpy() {});
       watcher.on(EV.CHANGE, spy);
       spy.should.not.have.been.called;
-      await fsp.writeFile(testPath, dateNow());
+      await write(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.been.calledWith(testPath);
       expect(spy.args[0][1]).to.be.ok; // stats
@@ -429,7 +430,7 @@ const runTests = (baseopts) => {
 
       watcher.on(EV.UNLINK_DIR, spy);
 
-      await fsp.rm(testDir2, { recursive: true });
+      await rm(testDir2, { recursive: true });
       await waitFor([[spy, 2]]);
 
       spy.should.have.been.calledWith(testDir2);
@@ -468,7 +469,7 @@ const runTests = (baseopts) => {
       const changeSpy = sinon.spy(function change() {});
       const testPath = dpath('add.txt');
       watcher.on(EV.UNLINK, unlinkSpy).on(EV.ADD, addSpy).on(EV.CHANGE, changeSpy);
-      await fsp.writeFile(testPath, 'hello');
+      await write(testPath, 'hello');
       await waitFor([[addSpy.withArgs(testPath), 1]]);
       unlinkSpy.should.not.have.been.called;
       changeSpy.should.not.have.been.called;
@@ -477,7 +478,7 @@ const runTests = (baseopts) => {
       unlinkSpy.should.have.been.calledWith(testPath);
 
       await delay(100);
-      await fsp.writeFile(testPath, dateNow());
+      await write(testPath, dateNow());
       await waitFor([[addSpy.withArgs(testPath), 2]]);
       addSpy.should.have.been.calledWith(testPath);
       changeSpy.should.not.have.been.called;
@@ -509,7 +510,7 @@ const runTests = (baseopts) => {
       watcher.on(EV.ADD, spy);
       spy.should.not.have.been.called;
       await fsp.mkdir(testDir, PERM);
-      await fsp.writeFile(testPath, dateNow());
+      await write(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.been.calledOnce;
       spy.should.have.been.calledWith(testPath);
@@ -548,7 +549,7 @@ const runTests = (baseopts) => {
       await fsp.rmdir(testPath);
       await waitFor([unlinkSpy]);
 
-      await fsp.writeFile(testPath, 'file content');
+      await write(testPath, 'file content');
       await waitFor([addSpy]);
 
       unlinkSpy.should.have.been.calledWith(testPath);
@@ -559,7 +560,7 @@ const runTests = (baseopts) => {
       const unlinkSpy = sinon.spy(function unlinkSpy() {});
       const addSpy = sinon.spy(function addSpy() {});
       const testPath = dpath('fileDir');
-      await fsp.writeFile(testPath, 'file content');
+      await write(testPath, 'file content');
       watcher.on(EV.UNLINK, unlinkSpy).on(EV.ADD_DIR, addSpy);
 
       await delay(300);
@@ -592,7 +593,7 @@ const runTests = (baseopts) => {
       const testPath = dpath('change.txt');
       const watcher = cwatch(testPath, options);
       const spy = await aspy(watcher, EV.CHANGE);
-      await fsp.writeFile(testPath, dateNow());
+      await write(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.always.been.calledWith(testPath);
     });
@@ -620,7 +621,7 @@ const runTests = (baseopts) => {
       unlinkSpy.should.have.been.calledWith(testPath);
 
       await delay();
-      await fsp.writeFile(testPath, 're-added');
+      await write(testPath, 're-added');
       await waitFor([addSpy]);
       addSpy.should.have.been.calledWith(testPath);
     });
@@ -632,8 +633,8 @@ const runTests = (baseopts) => {
       const spy = await aspy(watcher, EV.ALL);
 
       await delay();
-      await fsp.writeFile(siblingPath, dateNow());
-      await fsp.writeFile(testPath, dateNow());
+      await write(siblingPath, dateNow());
+      await write(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.always.been.calledWith(EV.ADD, testPath);
     });
@@ -641,18 +642,18 @@ const runTests = (baseopts) => {
     it('should detect safe-edit', async () => {
       const testPath = dpath('change.txt');
       const safePath = dpath('tmp.txt');
-      await fsp.writeFile(testPath, dateNow());
+      await write(testPath, dateNow());
       const watcher = cwatch(testPath, options);
       const spy = await aspy(watcher, EV.ALL);
 
       await delay();
-      await fsp.writeFile(safePath, dateNow());
+      await write(safePath, dateNow());
       await fsp.rename(safePath, testPath);
       await delay(300);
-      await fsp.writeFile(safePath, dateNow());
+      await write(safePath, dateNow());
       await fsp.rename(safePath, testPath);
       await delay(300);
-      await fsp.writeFile(safePath, dateNow());
+      await write(safePath, dateNow());
       await fsp.rename(safePath, testPath);
       await delay(300);
       await waitFor([spy]);
@@ -681,7 +682,7 @@ const runTests = (baseopts) => {
         const addSpy = sinon.spy(function addSpy() {});
         const testPath = dpath('unlink.txt');
         const otherPath = dpath('other.txt');
-        await fsp.writeFile(otherPath, 'other');
+        await write(otherPath, 'other');
         const watcher = cwatch([testPath, otherPath], options)
           .on(EV.UNLINK, unlinkSpy)
           .on(EV.ADD, addSpy);
@@ -695,7 +696,7 @@ const runTests = (baseopts) => {
         unlinkSpy.should.have.been.calledWith(testPath);
 
         await delay();
-        await fsp.writeFile(testPath, 're-added');
+        await write(testPath, 're-added');
         await waitFor([addSpy]);
         addSpy.should.have.been.calledWith(testPath);
       });
@@ -721,7 +722,7 @@ const runTests = (baseopts) => {
         unlinkSpy.should.have.been.calledWith(testPath);
 
         await delay();
-        await fsp.writeFile(testPath, 're-added');
+        await write(testPath, 're-added');
         await waitFor([addSpy]);
         addSpy.should.have.been.calledWith(testPath);
       });
@@ -745,7 +746,7 @@ const runTests = (baseopts) => {
         unlinkSpy.should.have.been.calledWith(testPath);
 
         await delay();
-        await fsp.writeFile(testPath, 're-added');
+        await write(testPath, 're-added');
         await waitFor([addSpy]);
         addSpy.should.have.been.calledWith(testPath);
       });
@@ -755,7 +756,7 @@ const runTests = (baseopts) => {
         const addSpy = sinon.spy(function addSpy() {});
         const testPath = dpath('unlink.txt');
         const otherPath = dpath('other.txt');
-        await fsp.writeFile(otherPath, 'other');
+        await write(otherPath, 'other');
         const watcher = cwatch([testPath, otherPath], options)
           .on(EV.UNLINK, unlinkSpy)
           .on(EV.ADD, addSpy);
@@ -773,7 +774,7 @@ const runTests = (baseopts) => {
         unlinkSpy.should.have.been.calledWith(testPath);
 
         await delay();
-        await fsp.writeFile(testPath, 're-added');
+        await write(testPath, 're-added');
         await waitFor([addSpy]);
         addSpy.should.have.been.calledWith(testPath);
       });
@@ -784,7 +785,7 @@ const runTests = (baseopts) => {
         const testPath = dpath('unlink.txt');
         const otherPath = dpath('other.txt');
         const other2Path = dpath('other2.txt');
-        await fsp.writeFile(otherPath, 'other');
+        await write(otherPath, 'other');
         // intentionally for this test don't write write(other2Path, 'other2');
         const watcher = cwatch([testPath, otherPath, other2Path], options)
           .on(EV.UNLINK, unlinkSpy)
@@ -798,7 +799,7 @@ const runTests = (baseopts) => {
         unlinkSpy.should.have.been.calledWith(testPath);
 
         await delay();
-        await fsp.writeFile(testPath, 're-added');
+        await write(testPath, 're-added');
         await waitFor([addSpy]);
         addSpy.should.have.been.calledWith(testPath);
       });
@@ -812,7 +813,7 @@ const runTests = (baseopts) => {
       const renamedDir = dpath('subdir-renamed');
       const expectedPath = sysPath.join(renamedDir, 'add.txt');
       await fsp.mkdir(testDir, PERM);
-      await fsp.writeFile(testPath, dateNow());
+      await write(testPath, dateNow());
       const watcher = cwatch(currentDir, options);
       const spy = await aspy(watcher, EV.ADD);
 
@@ -829,7 +830,7 @@ const runTests = (baseopts) => {
       const spy = await aspy(watcher, EV.ADD);
 
       await delay();
-      await fsp.writeFile(testPath, dateNow());
+      await write(testPath, dateNow());
       await waitFor([spy]);
       spy.should.have.been.calledWith(testPath);
     });
@@ -843,7 +844,7 @@ const runTests = (baseopts) => {
       await delay();
       await fsp.mkdir(testDir, PERM);
       await waitFor([spy.withArgs(EV.ADD_DIR)]);
-      await fsp.writeFile(testPath, 'hello');
+      await write(testPath, 'hello');
       await waitFor([spy.withArgs(EV.ADD)]);
       spy.should.have.been.calledWith(EV.ADD_DIR, testDir);
       spy.should.have.been.calledWith(EV.ADD, testPath);
@@ -852,13 +853,13 @@ const runTests = (baseopts) => {
   describe('not watch glob patterns', () => {
     it('should not confuse glob-like filenames with globs', async () => {
       const filePath = dpath('nota[glob].txt');
-      await fsp.writeFile(filePath, 'b');
+      await write(filePath, 'b');
       await delay();
       const spy = await aspy(cwatch(currentDir, options), EV.ALL);
       spy.should.have.been.calledWith(EV.ADD, filePath);
 
       await delay();
-      await fsp.writeFile(filePath, dateNow());
+      await write(filePath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE, filePath)]);
       spy.should.have.been.calledWith(EV.CHANGE, filePath);
     });
@@ -871,10 +872,10 @@ const runTests = (baseopts) => {
       const matchingFile = dpath('notag/b.txt');
       const matchingFile2 = dpath('notal');
       await fsp.mkdir(testDir, PERM);
-      await fsp.writeFile(filePath, 'b');
+      await write(filePath, 'b');
       await fsp.mkdir(matchingDir, PERM);
-      await fsp.writeFile(matchingFile, 'c');
-      await fsp.writeFile(matchingFile2, 'd');
+      await write(matchingFile, 'c');
+      await write(matchingFile2, 'd');
       const watcher = cwatch(watchPath, options);
       const spy = await aspy(watcher, EV.ALL);
 
@@ -883,7 +884,7 @@ const runTests = (baseopts) => {
       spy.should.not.have.been.calledWith(EV.ADD, matchingFile);
       spy.should.not.have.been.calledWith(EV.ADD, matchingFile2);
       await delay();
-      await fsp.writeFile(filePath, dateNow());
+      await write(filePath, dateNow());
 
       await waitFor([spy.withArgs(EV.CHANGE, filePath)]);
       spy.should.have.been.calledWith(EV.CHANGE, filePath);
@@ -896,10 +897,10 @@ const runTests = (baseopts) => {
       const matchingDir = dpath('notag');
       const matchingFile = dpath('notag/a.txt');
       const matchingFile2 = dpath('notal');
-      await fsp.writeFile(filePath, 'b');
+      await write(filePath, 'b');
       await fsp.mkdir(matchingDir, PERM);
-      await fsp.writeFile(matchingFile, 'c');
-      await fsp.writeFile(matchingFile2, 'd');
+      await write(matchingFile, 'c');
+      await write(matchingFile2, 'd');
       const watcher = cwatch(watchPath, options);
       const spy = await aspy(watcher, EV.ALL);
 
@@ -908,7 +909,7 @@ const runTests = (baseopts) => {
       spy.should.not.have.been.calledWith(EV.ADD, matchingFile);
       spy.should.not.have.been.calledWith(EV.ADD, matchingFile2);
       await delay();
-      await fsp.writeFile(filePath, dateNow());
+      await write(filePath, dateNow());
 
       await waitFor([spy.withArgs(EV.CHANGE, filePath)]);
       spy.should.have.been.calledWith(EV.CHANGE, filePath);
@@ -921,7 +922,7 @@ const runTests = (baseopts) => {
       linkedDir = sysPath.resolve(currentDir, '..', `${testId}-link`);
       await fsp.symlink(currentDir, linkedDir, isWindows ? 'dir' : null);
       await fsp.mkdir(dpath('subdir'), PERM);
-      await fsp.writeFile(dpath('subdir/add.txt'), 'b');
+      await write(dpath('subdir/add.txt'), 'b');
       return true;
     });
     afterEach(async () => {
@@ -946,7 +947,7 @@ const runTests = (baseopts) => {
       const watcher = cwatch(linkPath, options);
       const spy = await aspy(watcher, EV.ALL);
 
-      await fsp.writeFile(changePath, dateNow());
+      await write(changePath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
       spy.should.have.been.calledWith(EV.ADD, linkPath);
       spy.should.have.been.calledWith(EV.CHANGE, linkPath);
@@ -958,7 +959,7 @@ const runTests = (baseopts) => {
       const watcher = cwatch(dpath('subdir'), options);
       const spy = await aspy(watcher, EV.ALL);
 
-      await fsp.writeFile(changePath, dateNow());
+      await write(changePath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE, linkPath)]);
       spy.should.have.been.calledWith(EV.ADD, linkPath);
       spy.should.have.been.calledWith(EV.CHANGE, linkPath);
@@ -971,7 +972,7 @@ const runTests = (baseopts) => {
 
       spy.should.have.been.calledWith(EV.ADD_DIR, testDir);
       spy.should.have.been.calledWith(EV.ADD, testFile);
-      await fsp.writeFile(dpath('subdir/add.txt'), dateNow());
+      await write(dpath('subdir/add.txt'), dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
       spy.should.have.been.calledWith(EV.CHANGE, testFile);
     });
@@ -991,7 +992,7 @@ const runTests = (baseopts) => {
       const watcher = cwatch(linkedDir, options);
       const spy = await aspy(watcher, EV.CHANGE);
       const wa = spy.withArgs(linkedFilePath);
-      await fsp.writeFile(dpath('change.txt'), dateNow());
+      await write(dpath('change.txt'), dateNow());
       await waitFor([wa]);
       spy.should.have.been.calledWith(linkedFilePath);
     });
@@ -1059,7 +1060,7 @@ const runTests = (baseopts) => {
       const linkedFilePath = sysPath.join(linkedPath, 'text.txt');
       const linkPath = dpath('subdir/subsub');
       await fsp.mkdir(linkedPath, PERM);
-      await fsp.writeFile(linkedFilePath, 'b');
+      await write(linkedFilePath, 'b');
       await fsp.symlink(linkedPath, linkPath);
       const watcher2 = cwatch(dpath('subdir'), options);
       await waitForWatcher(watcher2);
@@ -1070,7 +1071,7 @@ const runTests = (baseopts) => {
       const spy = await aspy(watcher, EV.ALL);
 
       await delay();
-      await fsp.writeFile(linkedFilePath, dateNow());
+      await write(linkedFilePath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
       spy.should.have.been.calledWith(EV.CHANGE, watchedPath);
     });
@@ -1095,7 +1096,7 @@ const runTests = (baseopts) => {
       spy.should.have.been.calledWith(EV.ADD, testPath);
       spy.should.have.been.calledWith(EV.ADD_DIR, testDir);
       spy.should.not.have.been.calledWith(EV.ADD, dpath('unlink.txt'));
-      await fsp.writeFile(testPath, dateNow());
+      await write(testPath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
       spy.should.have.been.calledWith(EV.CHANGE, testPath);
     });
@@ -1108,7 +1109,7 @@ const runTests = (baseopts) => {
       spy.should.have.been.calledWith(EV.ADD, testPath);
       spy.should.have.been.calledWith(EV.ADD_DIR, testDir);
       spy.should.not.have.been.calledWith(EV.ADD, dpath('unlink.txt'));
-      await fsp.writeFile(testPath, dateNow());
+      await write(testPath, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
       spy.should.have.been.calledWith(EV.CHANGE, testPath);
     });
@@ -1170,7 +1171,7 @@ const runTests = (baseopts) => {
           const spy = await aspy(cwatch(currentDir, options), EV.ADD);
           spy.should.not.have.been.called;
           await fsp.mkdir(testDir, PERM);
-          await fsp.writeFile(testPath, dateNow());
+          await write(testPath, dateNow());
           await waitFor([spy]);
           spy.should.have.been.calledOnce;
           spy.should.have.been.calledWith(testPath);
@@ -1179,7 +1180,7 @@ const runTests = (baseopts) => {
           const testPath = dpath('change.txt');
           const spy = await aspy(cwatch(currentDir, options), EV.ALL);
           spy.should.not.have.been.called;
-          await fsp.writeFile(testPath, dateNow());
+          await write(testPath, dateNow());
           await waitFor([spy.withArgs(EV.CHANGE, testPath)]);
           spy.should.have.been.calledWith(EV.CHANGE, testPath);
           spy.should.not.have.been.calledWith(EV.ADD);
@@ -1191,7 +1192,7 @@ const runTests = (baseopts) => {
 
           await delay(200);
           const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-          await fsp.writeFile(testPath, dateNow());
+          await write(testPath, dateNow());
           await waitFor([spy]);
 
           await delay(200);
@@ -1208,9 +1209,9 @@ const runTests = (baseopts) => {
         };
         const testDir = dpath('subdir');
         await fsp.mkdir(testDir, PERM);
-        await fsp.writeFile(sysPath.join(testDir, 'add.txt'), '');
+        await write(sysPath.join(testDir, 'add.txt'), '');
         await fsp.mkdir(sysPath.join(testDir, 'subsub'), PERM);
-        await fsp.writeFile(sysPath.join(testDir, 'subsub', 'ab.txt'), '');
+        await write(sysPath.join(testDir, 'subsub', 'ab.txt'), '');
         const watcher = cwatch(testDir, options);
         const spy = await aspy(watcher, EV.ADD);
         spy.should.have.been.calledOnce;
@@ -1227,12 +1228,12 @@ const runTests = (baseopts) => {
         const testFile = sysPath.join(testDir, 'add.txt');
         options.ignored = testDir;
         await fsp.mkdir(testDir, PERM);
-        await fsp.writeFile(testFile, 'b');
+        await write(testFile, 'b');
         const watcher = cwatch(currentDir, options);
         const spy = await aspy(watcher, EV.ALL);
 
         await delay();
-        await fsp.writeFile(testFile, dateNow());
+        await write(testFile, dateNow());
 
         await delay(300);
         spy.should.not.have.been.calledWith(EV.ADD_DIR, testDir);
@@ -1243,13 +1244,13 @@ const runTests = (baseopts) => {
         options.cwd = currentDir;
         options.ignored = /add/;
 
-        await fsp.writeFile(dpath('add.txt'), 'b');
+        await write(dpath('add.txt'), 'b');
         const watcher = cwatch(currentDir, options);
         const spy = await aspy(watcher, EV.ALL);
 
         await delay();
-        await fsp.writeFile(dpath('add.txt'), dateNow());
-        await fsp.writeFile(dpath('change.txt'), dateNow());
+        await write(dpath('add.txt'), dateNow());
+        await write(dpath('change.txt'), dateNow());
 
         await waitFor([spy.withArgs(EV.CHANGE, 'change.txt')]);
         spy.should.not.have.been.calledWith(EV.ADD, 'add.txt');
@@ -1261,17 +1262,17 @@ const runTests = (baseopts) => {
     describe('depth', () => {
       beforeEach(async () => {
         await fsp.mkdir(dpath('subdir'), PERM);
-        await fsp.writeFile(dpath('subdir/add.txt'), 'b');
+        await write(dpath('subdir/add.txt'), 'b');
         await delay();
         await fsp.mkdir(dpath('subdir/subsub'), PERM);
-        await fsp.writeFile(dpath('subdir/subsub/ab.txt'), 'b');
+        await write(dpath('subdir/subsub/ab.txt'), 'b');
         await delay();
       });
       it('should not recurse if depth is 0', async () => {
         options.depth = 0;
         const watcher = cwatch(currentDir, options);
         const spy = await aspy(watcher, EV.ALL);
-        await fsp.writeFile(dpath('subdir/add.txt'), dateNow());
+        await write(dpath('subdir/add.txt'), dateNow());
         await waitFor([[spy, 4]]);
         spy.should.have.been.calledWith(EV.ADD_DIR, currentDir);
         spy.should.have.been.calledWith(EV.ADD_DIR, dpath('subdir'));
@@ -1287,9 +1288,9 @@ const runTests = (baseopts) => {
         const ignoredPath = dpath('subdir/subsub/ab.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
         await delay();
-        await fsp.writeFile(dpath('change.txt'), dateNow());
-        await fsp.writeFile(addPath, dateNow());
-        await fsp.writeFile(ignoredPath, dateNow());
+        await write(dpath('change.txt'), dateNow());
+        await write(addPath, dateNow());
+        await write(ignoredPath, dateNow());
         await waitFor([spy.withArgs(EV.CHANGE, addPath), spy.withArgs(EV.CHANGE, changePath)]);
         spy.should.have.been.calledWith(EV.ADD_DIR, dpath('subdir/subsub'));
         spy.should.have.been.calledWith(EV.CHANGE, changePath);
@@ -1349,13 +1350,13 @@ const runTests = (baseopts) => {
       });
       it('should ignore vim/emacs/Sublime swapfiles', async () => {
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await fsp.writeFile(dpath('.change.txt.swp'), 'a'); // vim
-        await fsp.writeFile(dpath('add.txt~'), 'a'); // vim/emacs
-        await fsp.writeFile(dpath('.subl5f4.tmp'), 'a'); // sublime
+        await write(dpath('.change.txt.swp'), 'a'); // vim
+        await write(dpath('add.txt~'), 'a'); // vim/emacs
+        await write(dpath('.subl5f4.tmp'), 'a'); // sublime
         await delay(300);
-        await fsp.writeFile(dpath('.change.txt.swp'), 'c');
-        await fsp.writeFile(dpath('add.txt~'), 'c');
-        await fsp.writeFile(dpath('.subl5f4.tmp'), 'c');
+        await write(dpath('.change.txt.swp'), 'c');
+        await write(dpath('add.txt~'), 'c');
+        await write(dpath('.subl5f4.tmp'), 'c');
         await delay(300);
         await fsp.unlink(dpath('.change.txt.swp'));
         await fsp.unlink(dpath('add.txt~'));
@@ -1365,7 +1366,7 @@ const runTests = (baseopts) => {
       });
       it('should ignore stale tilde files', async () => {
         options.ignoreInitial = false;
-        await fsp.writeFile(dpath('old.txt~'), 'a');
+        await write(dpath('old.txt~'), 'a');
         await delay();
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
         spy.should.not.have.been.calledWith(dpath('old.txt'));
@@ -1378,7 +1379,7 @@ const runTests = (baseopts) => {
         const watcher = cwatch('.', options);
         const spy = await aspy(watcher, EV.ALL);
         await fsp.unlink(dpath('unlink.txt'));
-        await fsp.writeFile(dpath('change.txt'), dateNow());
+        await write(dpath('change.txt'), dateNow());
         await waitFor([spy.withArgs(EV.UNLINK)]);
         spy.should.have.been.calledWith(EV.ADD, 'change.txt');
         spy.should.have.been.calledWith(EV.ADD, 'unlink.txt');
@@ -1426,7 +1427,7 @@ const runTests = (baseopts) => {
         const spy2 = await aspy(watcher2, EV.ALL);
 
         await fsp.unlink(dpath('unlink.txt'));
-        await fsp.writeFile(dpath('change.txt'), dateNow());
+        await write(dpath('change.txt'), dateNow());
         await Promise.all([watcherEvents, watcher2Events]);
         spy1.should.have.been.calledWith(EV.CHANGE, 'change.txt');
         spy1.should.have.been.calledWith(EV.UNLINK, 'unlink.txt');
@@ -1439,18 +1440,18 @@ const runTests = (baseopts) => {
         options.cwd = currentDir;
         options.ignored = ['ignored-option.txt', 'ignored.txt'];
         const files = ['.'];
-        await fsp.writeFile(dpath('change.txt'), 'hello');
-        await fsp.writeFile(dpath('ignored.txt'), 'ignored');
-        await fsp.writeFile(dpath('ignored-option.txt'), 'ignored option');
+        await write(dpath('change.txt'), 'hello');
+        await write(dpath('ignored.txt'), 'ignored');
+        await write(dpath('ignored-option.txt'), 'ignored option');
         const watcher = cwatch(files, options);
 
         const spy = await aspy(watcher, EV.ALL);
-        await fsp.writeFile(dpath('ignored.txt'), dateNow());
-        await fsp.writeFile(dpath('ignored-option.txt'), dateNow());
+        await write(dpath('ignored.txt'), dateNow());
+        await write(dpath('ignored-option.txt'), dateNow());
         await fsp.unlink(dpath('ignored.txt'));
         await fsp.unlink(dpath('ignored-option.txt'));
         await delay();
-        await fsp.writeFile(dpath('change.txt'), EV.CHANGE);
+        await write(dpath('change.txt'), EV.CHANGE);
         await waitFor([spy.withArgs(EV.CHANGE, 'change.txt')]);
         spy.should.have.been.calledWith(EV.ADD, 'change.txt');
         spy.should.not.have.been.calledWith(EV.ADD, 'ignored.txt');
@@ -1466,7 +1467,7 @@ const runTests = (baseopts) => {
       let filePath;
       beforeEach(async () => {
         filePath = dpath('add.txt');
-        await fsp.writeFile(filePath, 'b', { mode: 128 });
+        await write(filePath, 'b', { mode: 128 });
         await delay();
       });
       describe('false', () => {
@@ -1478,7 +1479,7 @@ const runTests = (baseopts) => {
           if (isWindows) return true;
           const spy = await aspy(cwatch(currentDir, options), EV.ALL);
           spy.should.not.have.been.calledWith(EV.ADD, filePath);
-          await fsp.writeFile(filePath, dateNow());
+          await write(filePath, dateNow());
 
           await delay(200);
           spy.should.not.have.been.calledWith(EV.CHANGE, filePath);
@@ -1512,14 +1513,14 @@ const runTests = (baseopts) => {
       it('should not emit add event before a file is fully written', async () => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await fsp.writeFile(testPath, 'hello');
+        await write(testPath, 'hello');
         await delay(200);
         spy.should.not.have.been.calledWith(EV.ADD);
       });
       it('should wait for the file to be fully written before emitting the add event', async () => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await fsp.writeFile(testPath, 'hello');
+        await write(testPath, 'hello');
 
         await delay(300);
         spy.should.not.have.been.called;
@@ -1529,7 +1530,7 @@ const runTests = (baseopts) => {
       it('should emit with the final stats', async () => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await fsp.writeFile(testPath, 'hello ');
+        await write(testPath, 'hello ');
 
         await delay(300);
         fs.appendFileSync(testPath, 'world!');
@@ -1541,16 +1542,16 @@ const runTests = (baseopts) => {
       it('should not emit change event while a file has not been fully written', async () => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await fsp.writeFile(testPath, 'hello');
+        await write(testPath, 'hello');
         await delay(100);
-        await fsp.writeFile(testPath, 'edit');
+        await write(testPath, 'edit');
         await delay(200);
         spy.should.not.have.been.calledWith(EV.CHANGE, testPath);
       });
       it('should not emit change event before an existing file is fully updated', async () => {
         const testPath = dpath('change.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await fsp.writeFile(testPath, 'hello');
+        await write(testPath, 'hello');
         await delay(300);
         spy.should.not.have.been.calledWith(EV.CHANGE, testPath);
       });
@@ -1568,18 +1569,18 @@ const runTests = (baseopts) => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
         await delay();
-        await fsp.writeFile(testPath, 'hello');
+        await write(testPath, 'hello');
 
         await waitFor([spy]);
         spy.should.have.been.calledWith(EV.ADD, testPath);
-        await fsp.writeFile(testPath, 'edit');
+        await write(testPath, 'edit');
         await waitFor([spy.withArgs(EV.CHANGE)]);
         spy.should.have.been.calledWith(EV.CHANGE, testPath);
       });
       it('should not raise any event for a file that was deleted before fully written', async () => {
         const testPath = dpath('add.txt');
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await fsp.writeFile(testPath, 'hello');
+        await write(testPath, 'hello');
         await delay(400);
         await fsp.unlink(testPath);
         await delay(400);
@@ -1595,7 +1596,7 @@ const runTests = (baseopts) => {
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
 
         await delay(400);
-        await fsp.writeFile(testPath, 'hello');
+        await write(testPath, 'hello');
 
         await waitFor([spy.withArgs(EV.ADD)]);
         spy.should.have.been.calledWith(EV.ADD, filename);
@@ -1612,10 +1613,10 @@ const runTests = (baseopts) => {
         options.cwd = sysPath.dirname(testPath);
         await fsp.mkdir(options.cwd);
         await delay();
-        await fsp.writeFile(testPath, 'hello');
+        await write(testPath, 'hello');
         await delay();
         const spy = await aspy(cwatch(currentDir, options), EV.ALL);
-        await fsp.writeFile(testPath, 'edit');
+        await write(testPath, 'edit');
         await delay();
         await fsp.unlink(testPath);
         await waitFor([spy.withArgs(EV.UNLINK)]);
@@ -1740,8 +1741,8 @@ const runTests = (baseopts) => {
       watcher.unwatch(dpath('subdir'));
 
       await delay();
-      await fsp.writeFile(dpath('subdir/add.txt'), dateNow());
-      await fsp.writeFile(dpath('change.txt'), dateNow());
+      await write(dpath('subdir/add.txt'), dateNow());
+      await write(dpath('change.txt'), dateNow());
       await waitFor([spy]);
 
       await delay(300);
@@ -1762,8 +1763,8 @@ const runTests = (baseopts) => {
 
       await delay();
       await fsp.unlink(unlinkFile);
-      await fsp.writeFile(addFile, dateNow());
-      await fsp.writeFile(changedFile, dateNow());
+      await write(addFile, dateNow());
+      await write(changedFile, dateNow());
       await waitFor([spy.withArgs(EV.CHANGE)]);
 
       await delay(300);
@@ -1782,8 +1783,8 @@ const runTests = (baseopts) => {
 
       await delay();
       watcher.unwatch(subdir);
-      await fsp.writeFile(dpath('subdir/add.txt'), dateNow());
-      await fsp.writeFile(dpath('change.txt'), dateNow());
+      await write(dpath('subdir/add.txt'), dateNow());
+      await write(dpath('change.txt'), dateNow());
       await waitFor([spy]);
 
       await delay(300);
@@ -1803,7 +1804,7 @@ const runTests = (baseopts) => {
       watcher.on(EV.ALL, spy).add(dpath('change.txt'));
 
       await delay();
-      await fsp.writeFile(dpath('change.txt'), dateNow());
+      await write(dpath('change.txt'), dateNow());
       console.log('a');
       await waitFor([spy]);
       console.log('b');
@@ -1818,8 +1819,8 @@ const runTests = (baseopts) => {
 
       await delay();
       await fsp.unlink(dpath('unlink.txt'));
-      await fsp.writeFile(dpath('subdir/add.txt'), dateNow());
-      await fsp.writeFile(dpath('change.txt'), dateNow());
+      await write(dpath('subdir/add.txt'), dateNow());
+      await write(dpath('change.txt'), dateNow());
       await waitFor([spy]);
 
       await delay(300);
@@ -1913,7 +1914,7 @@ const runTests = (baseopts) => {
         const folderPath = sysPath.join(packagesPath, `folder${i}`);
         await fsp.mkdir(folderPath);
         const filePath = sysPath.join(folderPath, `file${i}.js`);
-        await fsp.writeFile(sysPath.resolve(filePath), 'file content');
+        await write(sysPath.resolve(filePath), 'file content');
         const symlinkPath = sysPath.join(linkPath, `folder${i}`);
         await fsp.symlink(sysPath.resolve(folderPath), symlinkPath, isWindows ? 'dir' : null);
         watcher.add(sysPath.resolve(sysPath.join(symlinkPath, `file${i}.js`)));
@@ -1926,7 +1927,7 @@ const runTests = (baseopts) => {
 
       // Update a random generated file to fire an event
       const randomFilePath = sysPath.join(packagesPath, 'folder17', 'file17.js');
-      await fsp.writeFile(sysPath.resolve(randomFilePath), 'file content changer zeri ezhriez');
+      await write(sysPath.resolve(randomFilePath), 'file content changer zeri ezhriez');
 
       // Wait chokidar watch
       await delay(300);
@@ -1960,7 +1961,7 @@ const runTests = (baseopts) => {
         await delay(300);
         await fsp.mkdir(testSubDir);
         await delay(300);
-        await fsp.writeFile(testSubDirFile, '');
+        await write(testSubDirFile, '');
         await delay(300);
 
         const events = await eventsWaiter;
@@ -2006,7 +2007,7 @@ const runTests = (baseopts) => {
         await delay(300);
         await fsp.mkdir(testSubDir);
         await delay(300);
-        await fsp.writeFile(testSubDirFile, '');
+        await write(testSubDirFile, '');
         await delay(300);
 
         const events = await eventsWaiter;
@@ -2033,8 +2034,8 @@ const runTests = (baseopts) => {
       watcher.on(EV.ALL, spy);
       await watcher.close();
 
-      await fsp.writeFile(dpath('add.txt'), dateNow());
-      await fsp.writeFile(dpath('add.txt'), 'hello');
+      await write(dpath('add.txt'), dateNow());
+      await write(dpath('add.txt'), 'hello');
       await delay(300);
       await fsp.unlink(dpath('add.txt'));
 
@@ -2050,7 +2051,7 @@ const runTests = (baseopts) => {
       watcher2.on(EV.ADD, spy);
       await watcher1.close();
 
-      await fsp.writeFile(dpath('add.txt'), 'hello');
+      await write(dpath('add.txt'), 'hello');
       // Ensures EV_ADD is called. Immediately removing the file causes it to be skipped
       await delay(200);
       await fsp.unlink(dpath('add.txt'));
@@ -2072,7 +2073,7 @@ const runTests = (baseopts) => {
           process.stdout.write("closed");
         });
       })();`;
-      await fsp.writeFile(scriptFile, scriptContent);
+      await write(scriptFile, scriptContent);
       const obj = await exec(`node ${scriptFile}`);
       const { stdout } = obj;
       expect(stdout.toString()).to.equal('closed');
@@ -2096,7 +2097,7 @@ describe('chokidar', async () => {
   afterEach(async () => {
     const promises = WATCHERS.map((w) => w.close());
     await Promise.all(promises);
-    await fsp.rm(currentDir, { recursive: true });
+    await rm(currentDir, { recursive: true });
   });
 
   it('should expose public API methods', () => {
@@ -2111,27 +2112,27 @@ describe('chokidar', async () => {
 });
 async function main() {
   try {
-    await fsp.rm(FIXTURES_PATH, { recursive: true, force: true });
+    await rm(FIXTURES_PATH, { recursive: true, force: true });
     await fsp.mkdir(FIXTURES_PATH, { recursive: true, mode: PERM });
   } catch (error) {}
   process.chdir(FIXTURES_PATH);
   // Create many directories before tests.
   // Creating them in `beforeEach` increases chance of random failures.
-  const _content = await fsp.readFile(__filename, 'utf-8');
+  const _content = await read(__filename, 'utf-8');
   const _only = _content.match(/\sit\.only\(/g);
   const itCount = (_only && _only.length) || _content.match(/\sit\(/g).length;
   const testCount = itCount * 3;
   while (testId++ < testCount) {
     await fsp.mkdir(dpath(''), PERM);
-    await fsp.writeFile(dpath('change.txt'), 'b');
-    await fsp.writeFile(dpath('unlink.txt'), 'b');
+    await write(dpath('change.txt'), 'b');
+    await write(dpath('unlink.txt'), 'b');
   }
   testId = 0;
 
   await it.run(true);
 
   try {
-    await fsp.rm(FIXTURES_PATH, { recursive: true, force: true });
+    await rm(FIXTURES_PATH, { recursive: true, force: true });
   } catch (error) {}
   process.chdir(initialPath);
 }


### PR DESCRIPTION
Switches to `node:fs/promises` in tests

This also caught a couple of places where we were not awaiting FS operations, leading to flaky tests. Those are awaited now and should improve test runs.