### PR TITLE
test: strongly typed tests

### DIFF
--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -76,4 +76,4 @@ jobs:
       - uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
       - run: bun install
       - run: bun run build
-      - run: bun test.mjs
+      - run: bun index.test.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 /node_modules/
 /test-fixtures/
 /*.d.ts
+/*.d.mts
 /*.map
 /index.js
 /handler.js
 /esm
+/*.test.js
+/*.test.mjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,10 @@
       },
       "devDependencies": {
         "@paulmillr/jsbt": "0.2.1",
+        "@types/chai": "^5.0.1",
         "@types/node": "20.14.8",
+        "@types/sinon": "^17.0.3",
+        "@types/sinon-chai": "^4.0.0",
         "chai": "4.3.4",
         "micro-should": "0.5.0",
         "prettier": "3.1.1",
@@ -88,6 +91,23 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
+    "node_modules/@types/chai": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.0.1.tgz",
+      "integrity": "sha512-5T8ajsg3M/FOncpLYW7sdOcD6yf4+722sze/tc4KQV0P8Z2rAr3SAuHCIkYmYpt8VbcQlnz8SxlOlPQYefe4cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
@@ -97,6 +117,34 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinon-chai": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-4.0.0.tgz",
+      "integrity": "sha512-Uar+qk3TmeFsUWCwtqRNqNUE7vf34+MCJiQJR5M2rd4nCbhtE8RgTiHwN/mVwbfCjhmO6DiOel/MgzHkRMJJFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -281,9 +329,9 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.0.tgz",
-      "integrity": "sha512-4+hHiVsxlm4OVSNFpAIrOGyGeG9kNLGcLMqvSGL5Rj2NOYBDQiQ6lJRViwAZ80i8SNbY8kCpdjgJy5PNALARew==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "index.d.ts",
     "handler.js",
     "handler.d.ts",
-    "esm"
+    "esm",
+    "!**/*.test.*"
   ],
   "main": "./index.js",
   "module": "./esm/index.js",
@@ -29,7 +30,10 @@
   },
   "devDependencies": {
     "@paulmillr/jsbt": "0.2.1",
+    "@types/chai": "^5.0.1",
     "@types/node": "20.14.8",
+    "@types/sinon": "^17.0.3",
+    "@types/sinon-chai": "^4.0.0",
     "chai": "4.3.4",
     "micro-should": "0.5.0",
     "prettier": "3.1.1",
@@ -54,7 +58,7 @@
     "build": "tsc && tsc -p tsconfig.esm.json",
     "lint": "prettier --check src",
     "format": "prettier --write src",
-    "test": "node test.mjs"
+    "test": "node index.test.mjs"
   },
   "keywords": [
     "fs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   WatchHandlers,
 } from './handler.js';
 
-type AWF = {
+export type AWF = {
   stabilityThreshold: number;
   pollInterval: number;
 };

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -5,6 +5,7 @@
     "outDir": "esm",
     "module": "es2020",
     "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
     "noImplicitReturns": false,
     "sourceMap": false,
     "declarationMap": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "@paulmillr/jsbt/tsconfig.cjs.json",
   "compilerOptions": {
+    "module": "node16",
+    "moduleResolution": "node16",
+    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "outDir": ".",
     "noImplicitReturns": false,


### PR DESCRIPTION
I'm leaving this as a draft for now just to show you what I was thinking @paulmillr

Basically, this moves the tests into `src/` and converts them to typescript. I then ignored them from published files, etc.

All seems to work but these things had to change or need discussing (if we ever want this):

- we need `node16` resolution/module so `*.mts` is treated as ESM and `import.meta` exists
  - i manually diffed the build output before/after this change and it is identical
- we have a test which tries to mock `fs.Stat`, but this isn't possible in ESM
  - i've commented on the relevant test