### PR TITLE
chore: remove caret (^) from dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     }
   },
   "dependencies": {
-    "readdirp": "^4.1.0"
+    "readdirp": "4.1.0"
   },
   "devDependencies": {
     "@paulmillr/jsbt": "0.3.3",


### PR DESCRIPTION
# Purpose

Modify dependencies to remove the caret operator and use a fixed version.

# Description

Some libraries may introduce breaking changes even in minor or patch updates. Pinning avoids the risk caused by such violations.

I fixed it because the version of readdirp is specified with the caret operator.

When fixed, always use the fixed version to avoid unexpected behavior changes due to version updates of external packages.

<br/>

Could you please review it?

I always get help from chokidar

Thank you for your dedication