### PR TITLE
docs(README): add missing conversion from async generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ const watcher = watch(await Array.fromAsync(glob('**/*.js')));
 // v3
 chok.unwatch('**/*.js');
 // v4
-chok.unwatch(await glob('**/*.js'));
+chok.unwatch(await Array.fromAsync(glob('**/*.js')));
 ```
 
 ## Also


### PR DESCRIPTION
Following on https://github.com/paulmillr/chokidar/pull/1365, I believe `unwatch` should also take an array instead of the async generator returned by node's native `glob`. 

See also https://github.com/paulmillr/chokidar/issues/1350#issuecomment-2371913749