### PR TITLE
fix: reset lastIndex for regexp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,10 @@ const isMatcherObject = (matcher: Matcher): matcher is MatcherObject =>
 function createPattern(matcher: Matcher): MatchFunction {
   if (typeof matcher === 'function') return matcher;
   if (typeof matcher === 'string') return (string) => matcher === string;
-  if (matcher instanceof RegExp) return (string) => matcher.test(string);
+  if (matcher instanceof RegExp) return (string) => {
+    matcher.lastIndex = 0; // reset lastIndex for global regexes
+    return matcher.test(string)
+  };
   if (typeof matcher === 'object' && matcher !== null) {
     return (string) => {
       if (matcher.path === string) return true;


### PR DESCRIPTION
If the regular expression passed in carries the g modifier, multiple tests may produce unexpected results.

[developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test)