### PR TITLE
perf: re-use double slash regex

### DIFF
--- a/esm/package.json
+++ b/esm/package.json
@@ -1,1 +1,0 @@
-{ "type": "module", "sideEffects": false }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ const ONE_DOT = '.';
 const TWO_DOTS = '..';
 const STRING_TYPE = 'string';
 const BACK_SLASH_RE = /\\/g;
-const DOUBLE_SLASH_RE = /\/\//;
+const DOUBLE_SLASH_RE = /\/\//g;
 const DOT_RE = /\..*\.(sw[px])$|~$|\.subl.*\.tmp/;
 const REPLACER_RE = /^\.[/\\]/;
 
@@ -113,8 +113,7 @@ function normalizePath(path: Path): Path {
   path = path.replace(/\\/g, '/');
   let prepend = false;
   if (path.startsWith('//')) prepend = true;
-  const DOUBLE_SLASH_RE = /\/\//;
-  while (path.match(DOUBLE_SLASH_RE)) path = path.replace(DOUBLE_SLASH_RE, '/');
+  path = path.replace(DOUBLE_SLASH_RE, '/');
   if (prepend) path = '/' + path;
   return path;
 }
@@ -168,9 +167,7 @@ const toUnix = (string: string) => {
   if (str.startsWith(SLASH_SLASH)) {
     prepend = true;
   }
-  while (str.match(DOUBLE_SLASH_RE)) {
-    str = str.replace(DOUBLE_SLASH_RE, SLASH);
-  }
+  str = str.replace(DOUBLE_SLASH_RE, SLASH);
   if (prepend) {
     str = SLASH + str;
   }


### PR DESCRIPTION
Re-uses the regex and uses a global replace instead of a loop.

Also removes the left-over `esm/` directory now that we're esm-only.

cc @paulmillr
