### PR TITLE
Simplification of toUnix and normalizePath

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -531,7 +531,7 @@ export class NodeFsHandler {
     directory: string,
     initialAdd: boolean,
     wh: WatchHelper,
-    target: Path,
+    target: Path | undefined,
     dir: Path,
     depth: number,
     throttler: Throttler
@@ -539,7 +539,8 @@ export class NodeFsHandler {
     // Normalize the directory name on Windows
     directory = sp.join(directory, '');
 
-    throttler = this.fsw._throttle('readdir', directory, 1000) as Throttler;
+    const throttleKey = target ? `${directory}:${target}` : directory;
+    throttler = this.fsw._throttle('readdir', throttleKey, 1000) as Throttler;
     if (!throttler) return;
 
     const previous = this.fsw._getWatchedDir(wh.path);
@@ -632,7 +633,7 @@ export class NodeFsHandler {
     stats: Stats,
     initialAdd: boolean,
     depth: number,
-    target: string,
+    target: string | undefined,
     wh: WatchHelper,
     realpath: string
   ): Promise<(() => void) | undefined> {
@@ -713,7 +714,7 @@ export class NodeFsHandler {
           stats,
           initialAdd,
           depth,
-          target!,
+          target,
           wh,
           targetPath
         );

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -195,7 +195,6 @@ function waitForEvents(watcher: chokidar.FSWatcher, count: number) {
 
 const runTests = (baseopts: chokidar.ChokidarOptions) => {
   let macosFswatch = isMacos && !baseopts.usePolling;
-  let win32Polling = isWindows && baseopts.usePolling;
   let options: chokidar.ChokidarOptions;
   USE_SLOW_DELAY = macosFswatch ? 100 : undefined;
   baseopts.persistent = true;
@@ -568,13 +567,13 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
       watcher.on(EV.UNLINK_DIR, unlinkSpy).on(EV.ADD_DIR, addSpy);
       await mkdir(parentPath);
 
-      await delay(win32Polling ? 900 : 300);
+      await waitFor([[addSpy, 1, [parentPath]]]);
       await rmr(parentPath);
       await waitFor([[unlinkSpy, 1, [parentPath]]]);
       ok(calledWith(unlinkSpy, [parentPath]));
       await mkdir(parentPath);
 
-      await delay(win32Polling ? 2200 : 1200);
+      await waitFor([[addSpy, 2]]);
       await mkdir(subPath);
       await waitFor([[addSpy, 3]]);
       ok(calledWith(addSpy, [parentPath]));


### PR DESCRIPTION
Simplifies the implementation of `toUnix` and `normalizePath`. Adds a negative lookbehind for the `DOUBLE_SLASH_RE` constant. Removes the now unused `DOUBLE_SLASH` constant.