### PR TITLE
Watch for return of unlinked files

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -702,8 +702,7 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
       equal(getCallsWith(spy, [EV.CHANGE, testPath]).length, 3);
     });
 
-    // PR 682 is failing.
-    describe.skip('Skipping gh-682: should detect unlink', () => {
+    describe('should detect unlink', () => {
       it('should detect unlink while watching a non-existent second file in another directory', async () => {
         const testPath = dpath('unlink.txt');
         const otherDirPath = dpath('other-dir');

--- a/src/index.ts
+++ b/src/index.ts
@@ -876,8 +876,8 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     // via multiple paths (such as _handleFile and _handleDir)
     if (!this._throttle('remove', path, 100)) return;
 
-    // if the only watched file is removed, watch for its return
-    if (!isDirectory && this._watched.size === 1) {
+    // if a file is removed, watch for its return
+    if (!isDirectory) {
       this.add(directory, item, true);
     }
 


### PR DESCRIPTION
Problem manifests itself when one of the watched files gets removed and added back later on, chokidar emits unlink event and never adds file back. I hit this problem with tsup that [uses chokidar](https://github.com/egoist/tsup/blob/b906f86102c02f1ef66ebd4a3f7ff50bdc07af65/src/index.ts#L406-L409) under the hood, I guess it's because vim actually replaces edited file instead of directly writing to the same inode.

