### PR TITLE
chore: bump dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
         "readdirp": "^5.0.0"
       },
       "devDependencies": {
-        "@paulmillr/jsbt": "0.4.5",
-        "@types/node": "24.10.1",
-        "prettier": "3.5.2",
-        "tinyspy": "3.0.2",
-        "typescript": "5.9.2",
-        "upath": "2.0.1"
+        "@paulmillr/jsbt": "^0.5.0",
+        "@types/node": "^25.6.0",
+        "prettier": "^3.8.3",
+        "tinyspy": "^4.0.4",
+        "typescript": "^6.0.3",
+        "upath": "^3.0.7"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -27,29 +27,29 @@
       }
     },
     "node_modules/@paulmillr/jsbt": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@paulmillr/jsbt/-/jsbt-0.4.5.tgz",
-      "integrity": "sha512-T8874MAeO7Qf/TzDnord+bhRhI0DpotFpX+smB3ZS/f2ILcTkUJtRvPqrmaibgD4cZQSn/WYttEFFd5rtPcdlg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@paulmillr/jsbt/-/jsbt-0.5.0.tgz",
+      "integrity": "sha512-rJwIJ/DJ6PNafw74qYOnbZookNRKtQkqw62gS5vvQyS8YvZ8C/U10jSD93XTFkMG8+k3jVL7kaghLYZ7ES7UrA==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "jsbt": "jsbt.js"
+        "jsbt": "jsbt.bin.js"
       }
     },
     "node_modules/@types/node": {
-      "version": "24.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
-      "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -100,21 +100,34 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/upath": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
-      "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-3.0.7.tgz",
+      "integrity": "sha512-VjBBquch25nUGMuVBpOb2Cj3gc8Kb7lJBqbsXR/0anZ/5uJsL14Kpth9JKfnBsckxCfgIp6hPvcvvmZ97R9X7g==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/anodynos"
+        },
+        {
+          "type": "polar",
+          "url": "https://polar.sh/anodynos"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-upath"
+        }
+      ],
       "license": "MIT",
       "engines": {
-        "node": ">=4",
-        "yarn": "*"
+        "node": ">=20"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "readdirp": "^5.0.0"
   },
   "devDependencies": {
-    "@paulmillr/jsbt": "0.4.5",
-    "@types/node": "24.10.1",
-    "prettier": "3.5.2",
-    "tinyspy": "3.0.2",
-    "typescript": "5.9.2",
-    "upath": "2.0.1"
+    "@paulmillr/jsbt": "^0.5.0",
+    "@types/node": "^25.6.0",
+    "prettier": "^3.8.3",
+    "tinyspy": "^4.0.4",
+    "typescript": "^6.0.3",
+    "upath": "^3.0.7"
   },
   "sideEffects": false,
   "engines": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -95,7 +95,7 @@ const aspy = (
       clearTimeout(timeout);
       resolve(spy);
     });
-    watcher.on(eventName as keyof FSWatcherEventMap, handler);
+    watcher.on(eventName as keyof FSWatcherEventMap, handler as never);
   });
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "@paulmillr/jsbt/tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": ".",
+    "rootDir": "src",
     "module": "node16",
+    "types": ["node"],
     "moduleResolution": "node16",
     "allowSyntheticDefaultImports": true,
     "noImplicitReturns": false,


### PR DESCRIPTION
This updates typescript and a few other dev dependencies.

The type checker got smarter so one of the test functions no longer type
checks correctly thanks to spying on a complex union. So I have used an
`as never` cast.
