### PR TITLE
fix: default cwd to process.cwd() for relative ignore paths

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1278,6 +1278,29 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
         equal(calledWith(spy, [EV.ADD, testFile]), false);
         equal(calledWith(spy, [EV.CHANGE, testFile]), false);
       });
+      it('should ignore relative paths without explicit cwd', async () => {
+        const testDir = dpath('ignored-dir');
+        const testFile = sp.join(testDir, 'add.txt');
+        options.ignored = 'ignored-dir';
+        await mkdir(testDir);
+        await write(testFile, 'b');
+        const prevCwd = process.cwd();
+        process.chdir(currentDir);
+        try {
+          const watcher = cwatch(currentDir, options);
+          const spy = await aspy(watcher, EV.ALL);
+
+          await delay();
+          await write(testFile, time());
+
+          await delay(300);
+          equal(calledWith(spy, [EV.ADD_DIR, testDir]), false);
+          equal(calledWith(spy, [EV.ADD, testFile]), false);
+          equal(calledWith(spy, [EV.CHANGE, testFile]), false);
+        } finally {
+          process.chdir(prevCwd);
+        }
+      });
       it('should allow regex/fn ignores', async () => {
         options.cwd = currentDir;
         options.ignored = /add/;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1301,6 +1301,24 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
           process.chdir(prevCwd);
         }
       });
+      it('should ignore contents of relative dir with cwd set', async () => {
+        const testDir = dpath('subdir');
+        const testFile = sp.join(testDir, 'add.txt');
+        options.ignored = 'subdir';
+        options.cwd = currentDir;
+        await mkdir(testDir);
+        await write(testFile, 'b');
+        const watcher = cwatch(currentDir, options);
+        const spy = await aspy(watcher, EV.ALL);
+
+        await delay();
+        await write(testFile, time());
+
+        await delay(300);
+        equal(calledWith(spy, [EV.ADD_DIR, testDir]), false);
+        equal(calledWith(spy, [EV.ADD, testFile]), false);
+        equal(calledWith(spy, [EV.CHANGE, testFile]), false);
+      });
       it('should allow regex/fn ignores', async () => {
         options.cwd = currentDir;
         options.ignored = /add/;

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ const normalizePathToUnix = (path: Path) => toUnix(sp.normalize(toUnix(path)));
 
 // TODO: refactor
 const normalizeIgnored =
-  (cwd = '') =>
+  (cwd = process.cwd()) =>
   (path: Matcher): Matcher => {
     if (typeof path === 'string') {
       return normalizePathToUnix(sp.isAbsolute(path) ? path : sp.join(cwd, path));


### PR DESCRIPTION
## Summary
Default `cwd` option to `process.cwd()` instead of empty string to fix relative path matching in `ignored`.

## Problem
When `cwd` defaults to `""`, relative paths in the `ignored` option are joined with an empty string, producing paths that never match actual file paths. This means `ignored: 'node_modules'` silently fails to ignore anything unless `cwd` is explicitly set.

## Solution
Default `cwd` to `process.cwd()` when not provided in `normalizeIgnored`. This matches the intuitive behavior and was confirmed as the correct approach by collaborator @43081j.

## Test Plan
- [x] `ignored: 'relative-dir'` works without explicit `cwd`
- [x] Explicit `cwd` still works as before
- [x] Existing test suite passes (207 tests, 0 failures)

Fixes #1436