### PR TITLE
feat: support `recursive: true` (DRAFT/WIP)

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -43,6 +43,7 @@ const KEY_LISTENERS = 'listeners';
 const KEY_ERR = 'errHandlers';
 const KEY_RAW = 'rawEmitters';
 const HANDLER_KEYS = [KEY_LISTENERS, KEY_ERR, KEY_RAW];
+const BACKSLASH_PATTERN = /\\/g;
 
 // prettier-ignore
 const binaryExtensions = new Set([
@@ -280,6 +281,136 @@ const setFsWatchListener = (
   };
 };
 
+// recursive helpers
+// These have their own cache so they don't conflict with non-recursive watchers
+// on the same paths.
+//
+// Recursive listeners also deal with the emitted name rather than the one
+// they were setup with (compared to regular listeners).
+
+export type RecursiveFsWatchListener = (eventType: WatchEventType, filename: string) => void;
+
+export interface RecursiveWatchHandlers {
+  listener: RecursiveFsWatchListener;
+  errHandler: WatchHandlers['errHandler'];
+  rawEmitter: WatchHandlers['rawEmitter'];
+}
+
+export type FsWatchRecursiveContainer = {
+  listeners: Set<RecursiveFsWatchListener>;
+  errHandlers: Set<WatchHandlers['errHandler']>;
+  rawEmitters: Set<WatchHandlers['rawEmitter']>;
+  watcher: NativeFsWatcher;
+  // this means the watcher errored at some point and may be unreliable
+  watcherUnusable?: boolean;
+};
+
+const FsWatchRecursiveInstances = new Map<string, FsWatchRecursiveContainer>();
+
+const fsWatchRecursiveBroadcast = (
+  fullPath: Path,
+  listenerType: 'listeners' | 'errHandlers' | 'rawEmitters',
+  val1?: unknown,
+  val2?: unknown,
+  val3?: unknown
+) => {
+  const cont = FsWatchRecursiveInstances.get(fullPath);
+  if (!cont) return;
+  for (const listener of cont[listenerType]) {
+    (listener as (...args: unknown[]) => unknown)(val1, val2, val3);
+  }
+};
+
+function createFsWatchRecursiveInstance(
+  path: string,
+  options: Partial<FSWInstanceOptions>,
+  listener: RecursiveFsWatchListener,
+  errHandler: WatchHandlers['errHandler'],
+  emitRaw: WatchHandlers['rawEmitter']
+): NativeFsWatcher | undefined {
+  const handleEvent: WatchListener<string> = (rawEvent, evPath) => {
+    if (evPath == null || evPath === '') return;
+    const filename = isWindows ? evPath.replace(BACKSLASH_PATTERN, sp.sep) : evPath;
+    listener(rawEvent, filename);
+    emitRaw(rawEvent, sp.join(path, filename), { watchedPath: path });
+  };
+  try {
+    return fs_watch(path, { persistent: options.persistent, recursive: true }, handleEvent);
+  } catch (error) {
+    errHandler(error);
+    return undefined;
+  }
+}
+
+const setFsWatchRecursiveListener = (
+  path: string,
+  fullPath: string,
+  options: Partial<FSWInstanceOptions>,
+  handlers: RecursiveWatchHandlers
+): (() => void) | undefined => {
+  const { listener, errHandler, rawEmitter } = handlers;
+  let cont = FsWatchRecursiveInstances.get(fullPath);
+
+  let watcher: NativeFsWatcher | undefined;
+  if (!options.persistent) {
+    watcher = createFsWatchRecursiveInstance(path, options, listener, errHandler, rawEmitter);
+    if (!watcher) return;
+    return watcher.close.bind(watcher);
+  }
+  if (cont) {
+    addAndConvert(cont, KEY_LISTENERS, listener);
+    addAndConvert(cont, KEY_ERR, errHandler);
+    addAndConvert(cont, KEY_RAW, rawEmitter);
+  } else {
+    watcher = createFsWatchRecursiveInstance(
+      path,
+      options,
+      fsWatchRecursiveBroadcast.bind(null, fullPath, KEY_LISTENERS),
+      errHandler,
+      fsWatchRecursiveBroadcast.bind(null, fullPath, KEY_RAW)
+    );
+    if (!watcher) return;
+    watcher.on(EV.ERROR, async (error: Error & { code: string }) => {
+      const broadcastErr = fsWatchRecursiveBroadcast.bind(null, fullPath, KEY_ERR);
+      if (cont) cont.watcherUnusable = true;
+      // Same Windows EPERM workaround as the non-recursive path:
+      // https://github.com/joyent/node/issues/4337
+      if (isWindows && error.code === 'EPERM') {
+        try {
+          const fd = await open(path, 'r');
+          await fd.close();
+          broadcastErr(error);
+        } catch (err) {
+          // do nothing
+        }
+      } else {
+        broadcastErr(error);
+      }
+    });
+    cont = {
+      listeners: new Set([listener]),
+      errHandlers: new Set([errHandler]),
+      rawEmitters: new Set([rawEmitter]),
+      watcher,
+    };
+    FsWatchRecursiveInstances.set(fullPath, cont);
+  }
+
+  return () => {
+    delFromSet(cont, KEY_LISTENERS, listener);
+    delFromSet(cont, KEY_ERR, errHandler);
+    delFromSet(cont, KEY_RAW, rawEmitter);
+    if (isEmptySet(cont.listeners)) {
+      cont.watcher.close();
+      FsWatchRecursiveInstances.delete(fullPath);
+      HANDLER_KEYS.forEach(clearItem(cont));
+      // @ts-ignore
+      cont.watcher = undefined;
+      Object.freeze(cont);
+    }
+  };
+};
+
 // fs_watchFile helpers
 
 // object to hold per-process fs_watchFile instances
@@ -367,6 +498,26 @@ export class NodeFsHandler {
   constructor(fsW: FSWatcher) {
     this.fsw = fsW;
     this._boundHandleError = (error) => fsW._handleError(error as Error);
+  }
+
+  /**
+   * Watch a directory with `fs.watch(dir, { recursive: true })`, sharing one
+   * underlying watcher across FSWatcher instances on the same fullPath.
+   */
+  _watchWithNodeFsRecursive(
+    path: string,
+    listener: RecursiveFsWatchListener
+  ): (() => void) | undefined {
+    const opts = this.fsw.options;
+    const absolutePath = sp.resolve(path);
+    const options: Partial<FSWInstanceOptions> = {
+      persistent: opts.persistent,
+    };
+    return setFsWatchRecursiveListener(path, absolutePath, options, {
+      listener,
+      errHandler: this._boundHandleError,
+      rawEmitter: this.fsw._emitRaw,
+    });
   }
 
   /**
@@ -667,6 +818,121 @@ export class NodeFsHandler {
   }
 
   /**
+   * In recursive mode, adds the directory to the watch list and starts
+   * an initial scan of the directory to emit events for existing children.
+   *
+   * Note that symlinks are not followed in recursive mode.
+   */
+  async _handleDirRecursive(
+    dir: Path,
+    stats: Stats,
+    initialAdd: boolean,
+    wh: WatchHelper
+  ): Promise<(() => void) | undefined> {
+    const fsw = this.fsw;
+    const opts = fsw.options;
+
+    const parentDir = fsw._getWatchedDir(sp.dirname(dir));
+    const tracked = parentDir.has(sp.basename(dir));
+    if (!(initialAdd && opts.ignoreInitial) && !tracked) {
+      fsw._emit(EV.ADD_DIR, dir, stats);
+    }
+    parentDir.add(sp.basename(dir));
+    fsw._getWatchedDir(dir);
+
+    const emitInitial = !(initialAdd && opts.ignoreInitial);
+    const oDepth = opts.depth;
+
+    // Initial scan: seeds watched dirs and emits existing files.
+    await new Promise<void>((resolve) => {
+      let stream = fsw._readdirp(dir, {
+        fileFilter: (entry: EntryInfo) => wh.filterPath(entry),
+        directoryFilter: (entry: EntryInfo) => wh.filterDir(entry),
+        depth: oDepth == null ? Infinity : oDepth,
+      });
+      if (!stream) return resolve();
+      stream
+        .on(STR_DATA, (entry: EntryInfo) => {
+          if (fsw.closed) return;
+          const fullPath = entry.fullPath;
+          const itemDir = sp.dirname(fullPath);
+          const itemBase = sp.basename(fullPath);
+          const itemParent = fsw._getWatchedDir(itemDir);
+          if (itemParent.has(itemBase)) return;
+          itemParent.add(itemBase);
+          const isDir = entry.stats && entry.stats.isDirectory();
+          if (isDir) {
+            fsw._getWatchedDir(fullPath);
+            if (emitInitial) fsw._emit(EV.ADD_DIR, fullPath, entry.stats);
+          } else if (emitInitial) {
+            fsw._emit(EV.ADD, fullPath, entry.stats);
+          }
+        })
+        .on(EV.ERROR, this._boundHandleError)
+        .on(STR_END, () => resolve());
+    });
+
+    if (fsw.closed) return;
+
+    return this._watchWithNodeFsRecursive(dir, (_eventType, filename) => {
+      if (fsw.closed) return;
+      const fullPath = sp.join(dir, filename);
+      this._handleRecursiveEvent(dir, fullPath, wh).catch((e) => fsw._handleError(e as Error));
+    });
+  }
+
+  /**
+   * Resolve a single event from a native recursive watcher into a
+   * chokidar event
+   */
+  async _handleRecursiveEvent(rootDir: Path, fullPath: Path, wh: WatchHelper): Promise<void> {
+    const fsw = this.fsw;
+    if (fsw.closed) return;
+
+    const oDepth = fsw.options.depth;
+    if (oDepth != null) {
+      const rel = sp.relative(rootDir, fullPath);
+      const depth = rel ? rel.split(sp.sep).length : 0;
+      if (depth > oDepth + 1) return;
+    }
+
+    // Throttle duplicate events from the recursive watcher
+    if (!fsw._throttle(THROTTLE_MODE_WATCH, fullPath, 5)) return;
+
+    const directory = sp.dirname(fullPath);
+    const basename = sp.basename(fullPath);
+
+    let stats: Stats | undefined;
+    try {
+      stats = await statMethods[wh.statMethod](fullPath);
+    } catch {
+      const parent = fsw._getWatchedDir(directory);
+      if (parent.has(basename)) {
+        const isDir = fsw._watched.has(fullPath) || fsw._watched.has(sp.resolve(fullPath));
+        fsw._remove(directory, basename, isDir);
+      }
+      return;
+    }
+    if (fsw.closed) return;
+    if (fsw._isIgnored(fullPath, stats)) return;
+
+    const parent = fsw._getWatchedDir(directory);
+    const wasTracked = parent.has(basename);
+    if (stats.isDirectory()) {
+      if (!wasTracked) {
+        parent.add(basename);
+        fsw._getWatchedDir(fullPath);
+        fsw._emit(EV.ADD_DIR, fullPath, stats);
+      }
+    } else if (!wasTracked) {
+      parent.add(basename);
+      fsw._emit(EV.ADD, fullPath, stats);
+    } else {
+      fsw._emit(EV.CHANGE, fullPath, stats);
+    }
+  }
+
+  /**
    * Handle added file, directory, or glob pattern.
    * Delegates call to _handleFile / _handleDir after checks.
    * @param path to file or ir
@@ -709,15 +975,19 @@ export class NodeFsHandler {
         const absPath = sp.resolve(path);
         const targetPath = follow ? await fsrealpath(path) : path;
         if (this.fsw.closed) return;
-        closer = await this._handleDir(
-          wh.watchPath,
-          stats,
-          initialAdd,
-          depth,
-          target,
-          wh,
-          targetPath
-        );
+        if (this.fsw.options.recursive && !this.fsw.options.usePolling && !target) {
+          closer = await this._handleDirRecursive(wh.watchPath, stats, initialAdd, wh);
+        } else {
+          closer = await this._handleDir(
+            wh.watchPath,
+            stats,
+            initialAdd,
+            depth,
+            target,
+            wh,
+            targetPath
+          );
+        }
         if (this.fsw.closed) return;
         // preserve this symlink's target path
         if (absPath !== targetPath && targetPath !== undefined) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -358,9 +358,9 @@ const setFsWatchRecursiveListener = (
     return watcher.close.bind(watcher);
   }
   if (cont) {
-    addAndConvert(cont, KEY_LISTENERS, listener);
-    addAndConvert(cont, KEY_ERR, errHandler);
-    addAndConvert(cont, KEY_RAW, rawEmitter);
+    cont[KEY_LISTENERS].add(listener);
+    cont[KEY_ERR].add(errHandler);
+    cont[KEY_RAW].add(rawEmitter);
   } else {
     watcher = createFsWatchRecursiveInstance(
       path,
@@ -397,10 +397,10 @@ const setFsWatchRecursiveListener = (
   }
 
   return () => {
-    delFromSet(cont, KEY_LISTENERS, listener);
-    delFromSet(cont, KEY_ERR, errHandler);
-    delFromSet(cont, KEY_RAW, rawEmitter);
-    if (isEmptySet(cont.listeners)) {
+    cont[KEY_LISTENERS].delete(listener);
+    cont[KEY_ERR].delete(errHandler);
+    cont[KEY_RAW].delete(rawEmitter);
+    if (cont.listeners.size === 0) {
       cont.watcher.close();
       FsWatchRecursiveInstances.delete(fullPath);
       HANDLER_KEYS.forEach(clearItem(cont));

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1671,6 +1671,67 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
         equal(calledWith(spy, [EV.CHANGE, filename]), false);
       });
     });
+    if (!baseopts.usePolling) {
+      describe('recursive', () => {
+        beforeEach(() => {
+          options.recursive = true;
+          options.ignoreInitial = true;
+        });
+        it('should emit events for files in deeply nested subdirectories', async () => {
+          await mkdir(dpath('a/b/c'), { recursive: true });
+          await delay();
+          const nestedPath = dpath('a/b/c/add.txt');
+          const spy = await aspy(cwatch(currentDir, options), EV.ALL);
+          await write(nestedPath, time());
+          await waitFor([[spy, 1, [EV.ADD, nestedPath]]]);
+          ok(calledWith(spy, [EV.ADD, nestedPath]));
+
+          await write(nestedPath, 'updated');
+          await waitFor([[spy, 1, [EV.CHANGE, nestedPath]]]);
+          ok(calledWith(spy, [EV.CHANGE, nestedPath]));
+        });
+        it('should emit addDir for newly created nested directories', async () => {
+          const spy = await aspy(cwatch(currentDir, options), EV.ALL);
+          const newDir = dpath('newdir/inner');
+          const newFile = dpath('newdir/inner/add.txt');
+          await mkdir(newDir, { recursive: true });
+          await delay();
+          await write(newFile, time());
+          await waitFor([
+            [spy, 1, [EV.ADD_DIR, dpath('newdir')]],
+            [spy, 1, [EV.ADD_DIR, newDir]],
+            [spy, 1, [EV.ADD, newFile]],
+          ]);
+          ok(calledWith(spy, [EV.ADD_DIR, dpath('newdir')]));
+          ok(calledWith(spy, [EV.ADD_DIR, newDir]));
+          ok(calledWith(spy, [EV.ADD, newFile]));
+        });
+        it('should emit events on two watchers watching the same dir recursively', async () => {
+          await mkdir(dpath('shared'));
+          await delay();
+          const watcher1 = cwatch(currentDir, options);
+          const watcher2 = cwatch(currentDir, options);
+          const spy1 = await aspy(watcher1, EV.ALL);
+          const spy2 = await aspy(watcher2, EV.ALL);
+
+          const nestedPath = dpath('shared/add.txt');
+          await write(nestedPath, time());
+          await waitFor([
+            [spy1, 1, [EV.ADD, nestedPath]],
+            [spy2, 1, [EV.ADD, nestedPath]],
+          ]);
+          ok(calledWith(spy1, [EV.ADD, nestedPath]));
+          ok(calledWith(spy2, [EV.ADD, nestedPath]));
+
+          // Closing one watcher should not stop the other from receiving events
+          await watcher1.close();
+          const secondPath = dpath('shared/add2.txt');
+          await write(secondPath, time());
+          await waitFor([[spy2, 1, [EV.ADD, secondPath]]]);
+          ok(calledWith(spy2, [EV.ADD, secondPath]));
+        });
+      });
+    }
   });
   describe('getWatched', () => {
     it('should return the watched paths', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ type BasicOpts = {
   // useAsync?: boolean; // Use async for stat/readlink methods
 
   // ioLimit?: number; // Limit parallel IO operations (CPU usage + OS limits)
+  recursive?: boolean;
 };
 
 export type Throttler = {
@@ -58,6 +59,7 @@ export type ChokidarOptions = Partial<
 export type FSWInstanceOptions = BasicOpts & {
   ignored: Matcher[]; // string | fn ->
   awaitWriteFinish: false | AWF;
+  recursive: boolean;
 };
 
 export type ThrottleType = 'readdir' | 'watch' | 'add' | 'remove' | 'change';
@@ -375,6 +377,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
       ignored: _opts.ignored ? arrify(_opts.ignored) : arrify([]),
       awaitWriteFinish:
         awf === true ? DEF_AWF : typeof awf === 'object' ? { ...DEF_AWF, ...awf } : false,
+      recursive: _opts.recursive === true,
     };
 
     // Always default to polling on IBM i because fs.watch() is not available on IBM i.
@@ -953,7 +956,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
 
   _readdirp(root: Path, opts?: Partial<ReaddirpOptions>): ReaddirpStream | undefined {
     if (this.closed) return;
-    const options = { type: EV.ALL, alwaysStat: true, lstat: true, ...opts, depth: 0 };
+    const options = { type: EV.ALL, alwaysStat: true, lstat: true, depth: 0, ...opts };
     let stream: ReaddirpStream | undefined = readdirp(root, options);
     this._streams.add(stream);
     stream.once(STR_CLOSE, () => {


### PR DESCRIPTION
This introduces a new `recursive: boolean` option to the watcher.

Once set to `true`, the following will happen:

- When `_addToNodeFs` is called, we pass through to a new `_handleDirRecursive` codepath and hit the existing `_handleDir` otherwise
  - If polling is enabled, this is skipped
  - If we're watching a specific target (symlinks or single files), this is skipped
- The new `handleDirRecursive` is called with the dir we want to watch
- The directory is emitted as `ADD_DIR` if `ignoreInitial` is off
- The directory is noted (but no additional watcher added)
- We then do a one-off traversal of the directory to add any existing items
- Finally, we add or update a recursive `fs.watch` listener

In terms of listeners, the main difference is that a recursive listener deals directly with the _emitted_ path. A non-recursive listener deals with the _file being watched_.

Beyond that, everything should be roughly the same:
- If the item doesn't exist somehow, remove it from the watcher
- If the item is a directory, emit `ADD_DIR`
- If the item is a file and was not previously tracked, emit `ADD`
- If the item is a file and was previously tracked, emit `CHANGE`

**To avoid huge reworks, I tried to keep this new codepath standalone/separate**