### PR TITLE
fix: reintroduce graceful symlink infinite recursion

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -650,7 +650,8 @@ export class NodeFsHandler {
     let closer;
 
     const oDepth = this.fsw.options.depth;
-    if ((oDepth == null || depth <= oDepth) && !this.fsw._symlinkPaths.has(realpath)) {
+    const alreadyDescended = this.fsw._watched.has(realpath) && realpath !== dir;
+    if ((oDepth == null || depth <= oDepth) && !alreadyDescended) {
       if (!target) {
         await this._handleRead(dir, initialAdd, wh, target, dir, depth, throttler);
         if (this.fsw.closed) return;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -650,9 +650,12 @@ export class NodeFsHandler {
     let closer;
 
     const oDepth = this.fsw.options.depth;
-    const alreadyDescended = this.fsw._descendedRealpaths.has(realpath);
-    if ((oDepth == null || depth <= oDepth) && !alreadyDescended) {
-      this.fsw._descendedRealpaths.add(realpath);
+    const parentRealpath = this.fsw._dirRealpaths.get(sp.dirname(dir));
+    const isCycle =
+      parentRealpath !== undefined &&
+      (parentRealpath === realpath || parentRealpath.startsWith(realpath + sp.sep));
+    if ((oDepth == null || depth <= oDepth) && !isCycle) {
+      this.fsw._dirRealpaths.set(dir, realpath);
       if (!target) {
         await this._handleRead(dir, initialAdd, wh, target, dir, depth, throttler);
         if (this.fsw.closed) return;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -650,8 +650,9 @@ export class NodeFsHandler {
     let closer;
 
     const oDepth = this.fsw.options.depth;
-    const alreadyDescended = this.fsw._watched.has(realpath) && realpath !== dir;
+    const alreadyDescended = this.fsw._descendedRealpaths.has(realpath);
     if ((oDepth == null || depth <= oDepth) && !alreadyDescended) {
+      this.fsw._descendedRealpaths.add(realpath);
       if (!target) {
         await this._handleRead(dir, initialAdd, wh, target, dir, depth, throttler);
         if (this.fsw.closed) return;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1016,15 +1016,7 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
     });
     it('should not recurse indefinitely on circular symlinks', async () => {
       await symlink(currentDir, dpath('subdir/circular'), isWindows ? 'dir' : undefined);
-      await new Promise<void>((resolve, reject) => {
-        const watcher = cwatch(currentDir, options);
-        watcher.on(EV.ERROR, () => {
-          resolve();
-        });
-        watcher.on(EV.READY, () => {
-          reject('The watcher becomes ready, although he watches a circular symlink.');
-        });
-      });
+      await waitForWatcher(cwatch(currentDir, options));
     });
     it('should recognize changes following symlinked dirs', async () => {
       const linkedFilePath = sp.join(linkedDir, 'change.txt');

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,6 +327,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
   _streams: Set<ReaddirpStream>;
   _symlinkPaths: Map<Path, string | boolean>;
   _watched: Map<string, DirEntry>;
+  _descendedRealpaths: Set<string>;
 
   _pendingWrites: Map<string, any>;
   _pendingUnlinks: Map<string, EmitArgsWithName>;
@@ -351,6 +352,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     this._streams = new Set();
     this._symlinkPaths = new Map();
     this._watched = new Map();
+    this._descendedRealpaths = new Set();
 
     this._pendingWrites = new Map();
     this._pendingUnlinks = new Map();
@@ -558,6 +560,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     this._watched.clear();
     this._streams.clear();
     this._symlinkPaths.clear();
+    this._descendedRealpaths.clear();
     this._throttled.clear();
 
     this._closePromise = closers.length

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,7 +327,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
   _streams: Set<ReaddirpStream>;
   _symlinkPaths: Map<Path, string | boolean>;
   _watched: Map<string, DirEntry>;
-  _descendedRealpaths: Set<string>;
+  _dirRealpaths: Map<string, string>;
 
   _pendingWrites: Map<string, any>;
   _pendingUnlinks: Map<string, EmitArgsWithName>;
@@ -352,7 +352,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     this._streams = new Set();
     this._symlinkPaths = new Map();
     this._watched = new Map();
-    this._descendedRealpaths = new Set();
+    this._dirRealpaths = new Map();
 
     this._pendingWrites = new Map();
     this._pendingUnlinks = new Map();
@@ -560,7 +560,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     this._watched.clear();
     this._streams.clear();
     this._symlinkPaths.clear();
-    this._descendedRealpaths.clear();
+    this._dirRealpaths.clear();
     this._throttled.clear();
 
     this._closePromise = closers.length
@@ -918,6 +918,8 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     // or a bogus entry to a file, in either case we have to remove it
     this._watched.delete(path);
     this._watched.delete(fullPath);
+    this._dirRealpaths.delete(path);
+    this._dirRealpaths.delete(fullPath);
     const eventName: EventName = isDirectory ? EV.UNLINK_DIR : EV.UNLINK;
     if (wasTracked && !this._isIgnored(path)) this._emit(eventName, path);
 


### PR DESCRIPTION
The test for this originally used to assert that the watcher **did not
throw**.

Then in e487878 it was reversed to assert that the watcher **does
throw**.

It turns out the test passes because the OS throws an ELOOP error when
trying to stat a very deeply nested symlink. _Not_ because chokidar
threw an error, i.e. chokidar actually recurses into it very deeply
adding duplicate watchers until the OS throws.

**This change reverts the test to what it was originally, and changes the
gating to check a new set of seen realpaths rather than `_symlinkPaths`.**

Basically it seems:

- `_symlinkPaths` is a map of `symlinkPath -> realPath`
- This means the `!_symlinkPaths.has(realpath)` would only be hit if a
  symlink resolves to another symlink, or we already visited this exact
  symlink
- Changing it to use a separate map of visited directories means we can simply check if we resolve to a directory above ourselves that we already visited (i.e. a circular ref)

Doing a bunch of git research - it seems this back-and-forth was caused
by the fact we were using `_symlinkPaths` for both:

- Cycle detection (this logic)
- Unwatch cleanup (8f08914 tried to fix that but broke cycle detection)
