### PR TITLE
fix: unixify closer paths rather than normalize

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -935,7 +935,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
    * Closes only file-specific watchers
    */
   _closeFile(path: Path): void {
-    const key = sp.normalize(path);
+    const key = normalizePathToUnix(path);
     const closers = this._closers.get(key);
     if (!closers) return;
     closers.forEach((closer) => closer());
@@ -944,7 +944,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
 
   _addPathCloser(path: Path, closer: () => void): void {
     if (!closer) return;
-    const key = sp.normalize(path);
+    const key = normalizePathToUnix(path);
     let list = this._closers.get(key);
     if (!list) {
       list = [];


### PR DESCRIPTION
`normalize` will retain OS-specific path separators which actually
doesn't fix the problem this change originally intended to fix.

By using the same unixify helper we use when adding paths, we're
ensuring the same normalisation applies when reading/removing.

@sapphi-red FYI this is a miss from your branch I think.

