### PR TITLE
Add support for fs.watch(recursive: true)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.bak
 *.log
 /coverage/
+/.bench-tmp/
 /node_modules/
 /test-fixtures/
 /*.d.ts

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ chokidar.watch('file', {
   ignoreInitial: false,
   ignorePermissionErrors: false,
   usePolling: false,
+  useRecursiveWatch: false,
   alwaysStat: false,
 });
 ```
@@ -179,6 +180,13 @@ chokidar.watch('file', {
   - `binaryInterval` (default: `300`). Interval of file system
     polling for binary files.
     ([see list of binary extensions](https://github.com/sindresorhus/binary-extensions/blob/master/binary-extensions.json))
+- `useRecursiveWatch` (default: `false`). Whether to use a single native
+  `fs.watch(path, { recursive: true })` instance per watched directory tree,
+  instead of one watcher per directory. Uses ~3x less memory and makes startup
+  ~2x faster on big directory trees. Only effective on Linux, macOS and Windows
+  when `usePolling` is disabled; other platforms fall back to per-directory
+  watchers. Note that on Linux, node.js emulates recursive watching in
+  javascript, so the amount of kernel inotify watches stays the same.
 - `alwaysStat` (default: `false`). If relying upon the
   [`fs.Stats`](https://nodejs.org/api/fs.html#fs_class_fs_stats)
   object that may get passed with `add`, `addDir`, and `change` events, set

--- a/benchmark/bench.mjs
+++ b/benchmark/bench.mjs
@@ -1,0 +1,177 @@
+// Benchmark: chokidar per-directory watchers vs useRecursiveWatch
+// Run `npm run build` first: this imports the compiled index.js.
+// Usage: node benchmark/bench.mjs            (parent: builds tree, spawns one child per mode)
+//        node benchmark/bench.mjs <mode> <dir>  (child)
+import { execFile } from 'node:child_process';
+import { mkdir, readdir, readFile, readlink, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as sp from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const CHOKIDAR = new URL('../index.js', import.meta.url).href;
+const DIRS_L1 = 40;
+const DIRS_L2 = 50; // 40*50 = 2000 dirs
+const FILES_PER_DIR = 10; // 20_000 files
+const LATENCY_SAMPLES = 200;
+const CHURN_FILES = 500;
+
+const percentile = (arr, p) => {
+  const s = [...arr].sort((a, b) => a - b);
+  return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))];
+};
+
+async function inotifyWatchCount() {
+  let count = 0;
+  try {
+    const fds = await readdir('/proc/self/fd');
+    for (const fd of fds) {
+      try {
+        const link = await readlink(`/proc/self/fd/${fd}`);
+        if (!link.includes('inotify')) continue;
+        const info = await readFile(`/proc/self/fdinfo/${fd}`, 'utf8');
+        count += (info.match(/^inotify wd:/gm) || []).length;
+      } catch {}
+    }
+  } catch {}
+  return count;
+}
+
+async function runChild(mode, dir) {
+  const chokidar = await import(CHOKIDAR);
+  const opts = { useRecursiveWatch: mode === 'recursive', usePolling: mode === 'polling' };
+  if (mode === 'polling') opts.interval = 100;
+
+  global.gc();
+  const rssBefore = process.memoryUsage().rss;
+  const t0 = performance.now();
+  const watcher = chokidar.watch(dir, opts);
+  let initialEvents = 0;
+  watcher.on('all', () => initialEvents++);
+  await new Promise((resolve, reject) => {
+    watcher.on('ready', resolve);
+    watcher.on('error', reject);
+  });
+  const readyMs = performance.now() - t0;
+  global.gc();
+  const rssAfterReady = process.memoryUsage().rss;
+  const watches = await inotifyWatchCount();
+
+  // change latency: write existing files one at a time, await 'change'
+  const latencies = [];
+  const changeWaiters = new Map();
+  watcher.on('change', (p) => {
+    const w = changeWaiters.get(p);
+    if (w) {
+      latencies.push(performance.now() - w.t);
+      changeWaiters.delete(p);
+      w.resolve();
+    }
+  });
+  for (let i = 0; i < LATENCY_SAMPLES; i++) {
+    const l1 = i % DIRS_L1;
+    const l2 = (i * 7) % DIRS_L2;
+    const f = (i * 13) % FILES_PER_DIR;
+    const p = sp.join(dir, `d${l1}`, `d${l2}`, `f${f}.txt`);
+    await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        changeWaiters.delete(p);
+        latencies.push(NaN);
+        resolve();
+      }, 5000);
+      changeWaiters.set(p, {
+        t: performance.now(),
+        resolve: () => {
+          clearTimeout(timer);
+          resolve();
+        },
+      });
+      writeFile(p, `x${i}-${Date.now()}`);
+    });
+  }
+  const okLat = latencies.filter((x) => !Number.isNaN(x));
+
+  // churn: create N new files at once, time until all adds arrive
+  const churnDir = sp.join(dir, 'd0', 'd0');
+  let added = 0;
+  let churnDone;
+  const churnPromise = new Promise((r) => (churnDone = r));
+  watcher.on('add', () => {
+    added++;
+    if (added >= CHURN_FILES) churnDone();
+  });
+  const tChurn = performance.now();
+  await Promise.all(
+    Array.from({ length: CHURN_FILES }, (_, i) => writeFile(sp.join(churnDir, `new${i}.txt`), 'x'))
+  );
+  const churnTimeout = setTimeout(() => churnDone(), 15000);
+  await churnPromise;
+  clearTimeout(churnTimeout);
+  const churnMs = performance.now() - tChurn;
+
+  const tClose = performance.now();
+  await watcher.close();
+  const closeMs = performance.now() - tClose;
+
+  console.log(
+    JSON.stringify({
+      mode,
+      readyMs: +readyMs.toFixed(1),
+      initialEvents,
+      rssMB: +((rssAfterReady - rssBefore) / 1048576).toFixed(1),
+      inotifyWatches: watches,
+      latencyMedianMs: +percentile(okLat, 50).toFixed(2),
+      latencyP95Ms: +percentile(okLat, 95).toFixed(2),
+      latencyTimeouts: latencies.length - okLat.length,
+      churnAddsReceived: added,
+      churnMs: +churnMs.toFixed(1),
+      closeMs: +closeMs.toFixed(1),
+    })
+  );
+}
+
+async function main() {
+  const [, , mode, dir] = process.argv;
+  if (mode) return runChild(mode, dir);
+
+  const root = sp.join(tmpdir(), `chokidar-bench-${Date.now()}`);
+  console.error(`building tree: ${DIRS_L1 * DIRS_L2} dirs, ${DIRS_L1 * DIRS_L2 * FILES_PER_DIR} files in ${root}`);
+  for (let i = 0; i < DIRS_L1; i++) {
+    for (let j = 0; j < DIRS_L2; j++) {
+      const d = sp.join(root, `d${i}`, `d${j}`);
+      await mkdir(d, { recursive: true });
+      await Promise.all(
+        Array.from({ length: FILES_PER_DIR }, (_, f) => writeFile(sp.join(d, `f${f}.txt`), 'seed'))
+      );
+    }
+  }
+
+  const pexec = promisify(execFile);
+  const self = fileURLToPath(import.meta.url);
+  const results = [];
+  for (const m of ['per-directory', 'recursive']) {
+    for (let round = 0; round < 3; round++) {
+      // fresh churn dir per run
+      await rm(sp.join(root, 'd0', 'd0'), { recursive: true, force: true });
+      await mkdir(sp.join(root, 'd0', 'd0'), { recursive: true });
+      await Promise.all(
+        Array.from({ length: FILES_PER_DIR }, (_, f) =>
+          writeFile(sp.join(root, 'd0', 'd0', `f${f}.txt`), 'seed')
+        )
+      );
+      const { stdout } = await pexec(
+        process.execPath,
+        ['--expose-gc', self, m, root],
+        { timeout: 300000 }
+      );
+      const r = JSON.parse(stdout);
+      r.round = round;
+      results.push(r);
+      console.error(JSON.stringify(r));
+    }
+  }
+  await rm(root, { recursive: true, force: true });
+  console.log(JSON.stringify(results, null, 1));
+}
+
+main();

--- a/benchmark/bench.mjs
+++ b/benchmark/bench.mjs
@@ -1,7 +1,7 @@
 // Benchmark: chokidar per-directory watchers vs useRecursiveWatch
 // Run `npm run build` first: this imports the compiled index.js.
-// Usage: node benchmark/bench.mjs            (parent: builds tree, spawns one child per mode)
-//        node benchmark/bench.mjs <mode> <dir>  (child)
+// Usage: node benchmark/bench.mjs [file-count ...]   (parent)
+//        node benchmark/bench.mjs <mode> <dir> <json-config> [result-file]  (child)
 import { execFile } from 'node:child_process';
 import { mkdir, readdir, readFile, readlink, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -10,11 +10,42 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
 const CHOKIDAR = new URL('../index.js', import.meta.url).href;
-const DIRS_L1 = 40;
-const DIRS_L2 = 50; // 40*50 = 2000 dirs
-const FILES_PER_DIR = 10; // 20_000 files
-const LATENCY_SAMPLES = 200;
-const CHURN_FILES = 500;
+const DEFAULT_FILE_COUNTS = [20_000];
+const FILES_PER_DIR = Number(process.env.CHOKIDAR_BENCH_FILES_PER_DIR ?? 100);
+const LATENCY_SAMPLES = Number(process.env.CHOKIDAR_BENCH_LATENCY_SAMPLES ?? 200);
+const CHURN_FILES = Number(process.env.CHOKIDAR_BENCH_CHURN_FILES ?? 500);
+const ROUNDS = Number(process.env.CHOKIDAR_BENCH_ROUNDS ?? 3);
+const BENCH_TMPDIR = process.env.CHOKIDAR_BENCH_TMPDIR ?? tmpdir();
+const MODES = ['per-directory', 'recursive'];
+
+const parseCount = (raw) => {
+  const match = /^(\d+(?:\.\d+)?)([km])?$/i.exec(raw.replaceAll('_', ''));
+  if (!match) throw new Error(`invalid file count: ${raw}`);
+  const scale =
+    match[2]?.toLowerCase() === 'm' ? 1_000_000 : match[2]?.toLowerCase() === 'k' ? 1_000 : 1;
+  const value = Number(match[1]) * scale;
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`invalid file count: ${raw}`);
+  return value;
+};
+
+const treeConfig = (fileCount) => {
+  const leafDirs = Math.ceil(fileCount / FILES_PER_DIR);
+  const dirsL1 = Math.min(100, leafDirs);
+  const dirsL2 = Math.ceil(leafDirs / dirsL1);
+  return { fileCount, leafDirs, dirsL1, dirsL2, filesPerDir: FILES_PER_DIR };
+};
+
+const dirPathForIndex = (root, config, dirIndex) => {
+  const l1 = dirIndex % config.dirsL1;
+  const l2 = Math.floor(dirIndex / config.dirsL1);
+  return sp.join(root, `d${l1}`, `d${l2}`);
+};
+
+const filePathForIndex = (root, config, fileIndex) => {
+  const dirIndex = Math.floor(fileIndex / config.filesPerDir);
+  const fileInDir = fileIndex % config.filesPerDir;
+  return sp.join(dirPathForIndex(root, config, dirIndex), `f${fileInDir}.txt`);
+};
 
 const percentile = (arr, p) => {
   const s = [...arr].sort((a, b) => a - b);
@@ -37,7 +68,8 @@ async function inotifyWatchCount() {
   return count;
 }
 
-async function runChild(mode, dir) {
+async function runChild(mode, dir, rawConfig, resultFile) {
+  const config = JSON.parse(rawConfig);
   const chokidar = await import(CHOKIDAR);
   const opts = { useRecursiveWatch: mode === 'recursive', usePolling: mode === 'polling' };
   if (mode === 'polling') opts.interval = 100;
@@ -47,11 +79,13 @@ async function runChild(mode, dir) {
   const t0 = performance.now();
   const watcher = chokidar.watch(dir, opts);
   let initialEvents = 0;
-  watcher.on('all', () => initialEvents++);
+  const countInitial = () => initialEvents++;
+  watcher.on('all', countInitial);
   await new Promise((resolve, reject) => {
     watcher.on('ready', resolve);
     watcher.on('error', reject);
   });
+  watcher.off('all', countInitial);
   const readyMs = performance.now() - t0;
   global.gc();
   const rssAfterReady = process.memoryUsage().rss;
@@ -69,10 +103,7 @@ async function runChild(mode, dir) {
     }
   });
   for (let i = 0; i < LATENCY_SAMPLES; i++) {
-    const l1 = i % DIRS_L1;
-    const l2 = (i * 7) % DIRS_L2;
-    const f = (i * 13) % FILES_PER_DIR;
-    const p = sp.join(dir, `d${l1}`, `d${l2}`, `f${f}.txt`);
+    const p = filePathForIndex(dir, config, (i * 7919) % config.fileCount);
     await new Promise((resolve) => {
       const timer = setTimeout(() => {
         changeWaiters.delete(p);
@@ -92,7 +123,7 @@ async function runChild(mode, dir) {
   const okLat = latencies.filter((x) => !Number.isNaN(x));
 
   // churn: create N new files at once, time until all adds arrive
-  const churnDir = sp.join(dir, 'd0', 'd0');
+  const churnDir = dirPathForIndex(dir, config, 0);
   let added = 0;
   let churnDone;
   const churnPromise = new Promise((r) => (churnDone = r));
@@ -113,65 +144,97 @@ async function runChild(mode, dir) {
   await watcher.close();
   const closeMs = performance.now() - tClose;
 
-  console.log(
-    JSON.stringify({
-      mode,
-      readyMs: +readyMs.toFixed(1),
-      initialEvents,
-      rssMB: +((rssAfterReady - rssBefore) / 1048576).toFixed(1),
-      inotifyWatches: watches,
-      latencyMedianMs: +percentile(okLat, 50).toFixed(2),
-      latencyP95Ms: +percentile(okLat, 95).toFixed(2),
-      latencyTimeouts: latencies.length - okLat.length,
-      churnAddsReceived: added,
-      churnMs: +churnMs.toFixed(1),
-      closeMs: +closeMs.toFixed(1),
-    })
+  const result = {
+    fileCount: config.fileCount,
+    leafDirs: config.leafDirs,
+    topDirs: config.dirsL1,
+    mode,
+    readyMs: +readyMs.toFixed(1),
+    initialEvents,
+    rssMB: +((rssAfterReady - rssBefore) / 1048576).toFixed(1),
+    inotifyWatches: watches,
+    latencyMedianMs: +percentile(okLat, 50).toFixed(2),
+    latencyP95Ms: +percentile(okLat, 95).toFixed(2),
+    latencyTimeouts: latencies.length - okLat.length,
+    churnAddsReceived: added,
+    churnMs: +churnMs.toFixed(1),
+    closeMs: +closeMs.toFixed(1),
+  };
+  const line = JSON.stringify(result);
+  if (resultFile) await writeFile(resultFile, line);
+  process.stdout.write(`${line}\n`);
+}
+
+async function buildTree(root, config) {
+  for (let dirIndex = 0; dirIndex < config.leafDirs; dirIndex++) {
+    const d = dirPathForIndex(root, config, dirIndex);
+    await mkdir(d, { recursive: true });
+    const firstFile = dirIndex * config.filesPerDir;
+    const lastFile = Math.min(config.fileCount, firstFile + config.filesPerDir);
+    await Promise.all(
+      Array.from({ length: lastFile - firstFile }, (_, offset) =>
+        writeFile(sp.join(d, `f${offset}.txt`), 'seed')
+      )
+    );
+  }
+}
+
+async function resetChurnDir(root, config) {
+  const churnDir = dirPathForIndex(root, config, 0);
+  await rm(churnDir, { recursive: true, force: true });
+  await mkdir(churnDir, { recursive: true });
+  const filesInDir = Math.min(config.fileCount, config.filesPerDir);
+  await Promise.all(
+    Array.from({ length: filesInDir }, (_, f) => writeFile(sp.join(churnDir, `f${f}.txt`), 'seed'))
   );
 }
 
 async function main() {
-  const [, , mode, dir] = process.argv;
-  if (mode) return runChild(mode, dir);
-
-  const root = sp.join(tmpdir(), `chokidar-bench-${Date.now()}`);
-  console.error(`building tree: ${DIRS_L1 * DIRS_L2} dirs, ${DIRS_L1 * DIRS_L2 * FILES_PER_DIR} files in ${root}`);
-  for (let i = 0; i < DIRS_L1; i++) {
-    for (let j = 0; j < DIRS_L2; j++) {
-      const d = sp.join(root, `d${i}`, `d${j}`);
-      await mkdir(d, { recursive: true });
-      await Promise.all(
-        Array.from({ length: FILES_PER_DIR }, (_, f) => writeFile(sp.join(d, `f${f}.txt`), 'seed'))
-      );
-    }
-  }
+  const [, , mode, dir, rawConfig, resultFile] = process.argv;
+  if (MODES.includes(mode)) return runChild(mode, dir, rawConfig, resultFile);
+  if (mode === 'reset') return resetChurnDir(dir, JSON.parse(rawConfig));
 
   const pexec = promisify(execFile);
   const self = fileURLToPath(import.meta.url);
   const results = [];
-  for (const m of ['per-directory', 'recursive']) {
-    for (let round = 0; round < 3; round++) {
-      // fresh churn dir per run
-      await rm(sp.join(root, 'd0', 'd0'), { recursive: true, force: true });
-      await mkdir(sp.join(root, 'd0', 'd0'), { recursive: true });
-      await Promise.all(
-        Array.from({ length: FILES_PER_DIR }, (_, f) =>
-          writeFile(sp.join(root, 'd0', 'd0', `f${f}.txt`), 'seed')
-        )
-      );
-      const { stdout } = await pexec(
-        process.execPath,
-        ['--expose-gc', self, m, root],
-        { timeout: 300000 }
-      );
-      const r = JSON.parse(stdout);
-      r.round = round;
-      results.push(r);
-      console.error(JSON.stringify(r));
+  const fileCounts = process.argv.slice(2).map(parseCount);
+  const counts = fileCounts.length ? fileCounts : DEFAULT_FILE_COUNTS;
+  await mkdir(BENCH_TMPDIR, { recursive: true });
+  for (const fileCount of counts) {
+    const config = treeConfig(fileCount);
+    const root = sp.join(BENCH_TMPDIR, `chokidar-bench-${fileCount}-${Date.now()}`);
+    console.error(
+      `building tree: ${config.fileCount} files, ${config.leafDirs} leaf dirs, ${config.dirsL1} top dirs in ${root}`
+    );
+    await buildTree(root, config);
+    try {
+      for (let round = 0; round < ROUNDS; round++) {
+        const order = round % 2 === 0 ? MODES : [...MODES].reverse();
+        for (const m of order) {
+          await resetChurnDir(root, config);
+          const resultFile = sp.join(
+            BENCH_TMPDIR,
+            `chokidar-bench-result-${process.pid}-${fileCount}-${m}-${round}-${Date.now()}.json`
+          );
+          await pexec(
+            process.execPath,
+            ['--expose-gc', self, m, root, JSON.stringify(config), resultFile],
+            {
+              timeout: 900000,
+            }
+          );
+          const r = JSON.parse(await readFile(resultFile, 'utf8'));
+          await rm(resultFile, { force: true });
+          r.round = round;
+          results.push(r);
+          console.error(JSON.stringify(r));
+        }
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
   }
-  await rm(root, { recursive: true, force: true });
   console.log(JSON.stringify(results, null, 1));
 }
 
-main();
+await main();

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -20,6 +20,9 @@ export const isMacos: boolean = pl === 'darwin';
 export const isLinux: boolean = pl === 'linux';
 export const isFreeBSD: boolean = pl === 'freebsd';
 export const isIBMi: boolean = osType() === 'OS400';
+// Platforms where fs.watch supports `recursive: true` natively
+// (others throw ERR_FEATURE_UNAVAILABLE_ON_PLATFORM)
+export const canUseRecursiveWatch: boolean = (isWindows || isMacos || isLinux) && !isIBMi;
 
 export const EVENTS = {
   ALL: 'all',
@@ -358,6 +361,8 @@ const setFsWatchFileListener = (
   };
 };
 
+type RecursiveSeenEntry = { mtimeMs: number; size: number; addedAt?: number };
+
 /**
  * @mixin
  */
@@ -465,7 +470,7 @@ export class NodeFsHandler {
 
     // emit an add event if we're supposed to
     if (!(initialAdd && this.fsw.options.ignoreInitial) && this.fsw._isntIgnored(file)) {
-      if (!this.fsw._throttle(EV.ADD, file, 0)) return;
+      if (!this.fsw._throttle(EV.ADD, file, 0)) return closer;
       this.fsw._emit(EV.ADD, file, stats);
     }
 
@@ -667,6 +672,238 @@ export class NodeFsHandler {
   }
 
   /**
+   * Watch a whole directory tree with a single native `fs.watch(recursive: true)`
+   * instance instead of one watcher per directory (`useRecursiveWatch` option).
+   * Raw events are normalized into add/addDir/change/unlink/unlinkDir by
+   * stat-ing the reported path and diffing against the tracked directory tree.
+   * @returns closer for the watcher instance
+   */
+  async _handleDirRecursive(
+    dir: string,
+    stats: Stats,
+    initialAdd: boolean,
+    depth: number,
+    wh: WatchHelper,
+    realpath: string
+  ): Promise<(() => void) | undefined> {
+    const fsw = this.fsw;
+    const opts = fsw.options;
+    const oDepth = opts.depth;
+    // last seen stats of files reported by raw events; used to suppress the
+    // duplicate 'change' that immediately follows a create
+    const seen = new Map<Path, RecursiveSeenEntry>();
+    let watcher: NativeFsWatcher | undefined;
+    if ((oDepth == null || depth <= oDepth) && !fsw._symlinkPaths.has(realpath)) {
+      try {
+        watcher = fs_watch(
+          dir,
+          { persistent: opts.persistent, recursive: true },
+          (rawEvent, evPath) => {
+            this._handleRecursiveEvent(dir, wh, seen, rawEvent, evPath).catch(
+              this._boundHandleError
+            );
+          }
+        );
+      } catch (error) {
+        // recursive watching unavailable here (e.g. exotic filesystem):
+        // fall back to one watcher per directory
+        return this._handleDir(dir, stats, initialAdd, depth, undefined, wh, realpath);
+      }
+      watcher.on(EV.ERROR, this._boundHandleError);
+    }
+
+    const parentDir = fsw._getWatchedDir(sp.dirname(dir));
+    const tracked = parentDir.has(sp.basename(dir));
+    if (!(initialAdd && opts.ignoreInitial) && !tracked) fsw._emit(EV.ADD_DIR, dir, stats);
+    parentDir.add(sp.basename(dir));
+    fsw._getWatchedDir(dir);
+
+    if (!watcher) return;
+    await this._recursiveScan(
+      dir,
+      initialAdd,
+      wh,
+      depth,
+      oDepth == null ? undefined : oDepth - depth
+    );
+    if (fsw.closed) {
+      watcher.close();
+      return;
+    }
+    return () => {
+      seen.clear();
+      watcher.close();
+    };
+  }
+
+  /**
+   * Emit add/addDir for (and track) everything inside a dir watched recursively.
+   * Used for the initial scan and for directories that appear with contents
+   * already inside (e.g. moved in), which the OS watcher reports as one event.
+   * @param baseDepth depth of `dir` relative to the user-supplied path
+   * @param maxDepth remaining readdirp depth budget; undefined means unlimited
+   */
+  _recursiveScan(
+    dir: string,
+    initialAdd: boolean,
+    wh: WatchHelper,
+    baseDepth: number,
+    maxDepth: number | undefined
+  ): Promise<void> {
+    const fsw = this.fsw;
+    return new Promise((resolve) => {
+      const stream = fsw._readdirp(dir, {
+        fileFilter: (entry: EntryInfo) => wh.filterPath(entry),
+        // never descend into symlinked dirs: readdirp classifies them as
+        // directories, but they are still offered to fileFilter afterwards
+        // (type: 'all'), so the data handler below delegates them
+        directoryFilter: (entry: EntryInfo) =>
+          !entry.stats?.isSymbolicLink() && wh.filterDir(entry),
+        depth: maxDepth,
+      });
+      if (!stream) return resolve();
+      stream
+        .on(STR_DATA, (entry: EntryInfo) => {
+          if (fsw.closed) return;
+          const path = sp.join(dir, entry.path);
+          const item = sp.basename(path);
+          const stats = entry.stats!;
+          if (stats.isSymbolicLink()) {
+            // symlinks keep using the per-directory machinery
+            this._handleSymlink(entry, sp.dirname(path), path, item).then((handled) => {
+              if (handled || fsw.closed) return;
+              fsw._incrReadyCount();
+              const entryDepth = baseDepth + entry.path.split(/[/\\]/).length;
+              this._addToNodeFs(path, initialAdd, wh, entryDepth);
+            });
+            return;
+          }
+          const parent = fsw._getWatchedDir(sp.dirname(path));
+          if (parent.has(item)) return; // a raw event won the race
+          parent.add(item);
+          const isDir = stats.isDirectory();
+          if (isDir) fsw._getWatchedDir(path);
+          if (initialAdd && fsw.options.ignoreInitial) return;
+          fsw._emit(isDir ? EV.ADD_DIR : EV.ADD, path, stats);
+        })
+        .on(EV.ERROR, this._boundHandleError)
+        .once(STR_END, resolve)
+        .once(STR_CLOSE, resolve);
+    });
+  }
+
+  /**
+   * Normalize one raw event from a recursive fs.watch instance.
+   */
+  async _handleRecursiveEvent(
+    root: string,
+    wh: WatchHelper,
+    seen: Map<Path, RecursiveSeenEntry>,
+    rawEvent: WatchEventType,
+    evPath: string | null,
+    retried?: boolean
+  ): Promise<void> {
+    const fsw = this.fsw;
+    if (fsw.closed) return;
+    if (!retried) fsw._emitRaw(rawEvent, evPath!, { watchedPath: root });
+    if (!evPath) return;
+    const path = sp.join(root, evPath);
+    const oDepth = fsw.options.depth;
+    // number of path segments from root; matches the `depth` passed around
+    // by _handleRead/_addToNodeFs in the per-directory implementation
+    const parts = evPath.split(/[/\\]/);
+    const depth = parts.length;
+    if (oDepth != null && depth > oDepth + 1) return;
+    if (fsw._isIgnored(path)) return;
+    // in per-directory mode an ignored dir is never watched, so its contents
+    // never emit events; emulate that by checking every ancestor dir
+    let ancestor = root;
+    for (let i = 0; i < parts.length - 1; i++) {
+      ancestor = sp.join(ancestor, parts[i]);
+      if (fsw._isIgnored(ancestor)) return;
+    }
+
+    const parentPath = sp.dirname(path);
+    const item = sp.basename(path);
+    let stats: Stats;
+    try {
+      stats = await lstat(path);
+    } catch (error) {
+      // path is gone: emit unlink(s) if it was tracked
+      seen.delete(path);
+      if (fsw.closed) return;
+      if (!fsw._getWatchedDir(parentPath).has(item)) return;
+      // a tracked symlink may be atomically replaced (unlink + re-link);
+      // re-check briefly later before emitting unlink, like the throttled
+      // rescan of the per-directory implementation does implicitly
+      if (!retried && fsw._symlinkPaths.has(sp.resolve(path))) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        if (fsw.closed) return;
+        return this._handleRecursiveEvent(root, wh, seen, rawEvent, evPath, true);
+      }
+      fsw._remove(parentPath, item);
+      return;
+    }
+    if (fsw.closed) return;
+    if (fsw._isIgnored(path, stats)) return;
+
+    if (stats.isSymbolicLink()) {
+      if (fsw.options.followSymlinks) {
+        // delegate to the per-directory machinery, once per link path
+        const full = sp.resolve(path);
+        if (!fsw._symlinkPaths.has(full)) {
+          fsw._symlinkPaths.set(full, true);
+          fsw._incrReadyCount();
+          this._addToNodeFs(path, false, wh, depth);
+        }
+        return;
+      }
+      // followSymlinks: false — fall through and treat the link itself like
+      // a file: a replaced link has a new inode and mtime, which emits change
+      fsw._symlinkPaths.set(sp.resolve(path), true);
+    }
+
+    const parent = fsw._getWatchedDir(parentPath);
+    if (stats.isDirectory()) {
+      if (parent.has(item)) return; // events for dir contents arrive separately
+      parent.add(item);
+      fsw._getWatchedDir(path);
+      fsw._emit(EV.ADD_DIR, path, stats);
+      // pick up entries that existed before the event was reported
+      // (e.g. a directory moved in with contents)
+      if (oDepth == null || depth <= oDepth) {
+        await this._recursiveScan(
+          path,
+          false,
+          wh,
+          depth,
+          oDepth == null ? undefined : oDepth - depth
+        );
+      }
+      return;
+    }
+
+    const prev = seen.get(path);
+    if (!parent.has(item)) {
+      seen.set(path, { mtimeMs: stats.mtimeMs, size: stats.size, addedAt: Date.now() });
+      parent.add(item);
+      fsw._emit(EV.ADD, path, stats);
+      return;
+    }
+    // a create is reported as a rename + change event pair; suppress the
+    // trailing change, like the per-directory implementation does implicitly
+    // (a file's own watcher only attaches after its add is emitted)
+    const justAdded = prev != null && prev.addedAt != null && Date.now() - prev.addedAt < 50;
+    const changed = !prev || prev.mtimeMs !== stats.mtimeMs || prev.size !== stats.size;
+    seen.set(path, {
+      mtimeMs: stats.mtimeMs,
+      size: stats.size,
+      addedAt: justAdded ? prev.addedAt : undefined,
+    });
+    if (changed && !justAdded) fsw._emit(EV.CHANGE, path, stats);
+  }
+
+  /**
    * Handle added file, directory, or glob pattern.
    * Delegates call to _handleFile / _handleDir after checks.
    * @param path to file or ir
@@ -709,15 +946,12 @@ export class NodeFsHandler {
         const absPath = sp.resolve(path);
         const targetPath = follow ? await fsrealpath(path) : path;
         if (this.fsw.closed) return;
-        closer = await this._handleDir(
-          wh.watchPath,
-          stats,
-          initialAdd,
-          depth,
-          target,
-          wh,
-          targetPath
-        );
+        const opts = this.fsw.options;
+        const recursive =
+          opts.useRecursiveWatch && !opts.usePolling && !target && canUseRecursiveWatch;
+        closer = recursive
+          ? await this._handleDirRecursive(wh.watchPath, stats, initialAdd, depth, wh, targetPath)
+          : await this._handleDir(wh.watchPath, stats, initialAdd, depth, target, wh, targetPath);
         if (this.fsw.closed) return;
         // preserve this symlink's target path
         if (absPath !== targetPath && targetPath !== undefined) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,7 +19,7 @@ import { type Spy, type SpyFn, spy as createSpy } from 'tinyspy';
 import upath from 'upath';
 import type { EmitArgs, FSWatcherEventMap } from './index.js';
 
-import { EVENTS as EV, isIBMi, isMacos, isWindows } from './handler.js';
+import { canUseRecursiveWatch, EVENTS as EV, isIBMi, isMacos, isWindows } from './handler.js';
 import * as chokidar from './index.js';
 
 const TEST_TIMEOUT = 32000; // ms
@@ -2113,6 +2113,9 @@ describe('chokidar', async () => {
     describe('fs.watch (non-polling)', runTests.bind(this, { usePolling: false }));
   }
   describe('fs.watchFile (polling)', runTests.bind(this, { usePolling: true, interval: 10 }));
+  if (canUseRecursiveWatch) {
+    describe('fs.watch (recursive)', runTests.bind(this, { useRecursiveWatch: true }));
+  }
 });
 async function main() {
   const initialPath = process.cwd();
@@ -2128,7 +2131,7 @@ async function main() {
   const _content = await read(_filename, 'utf-8');
   const _only = _content.match(/\sit\.only\(/g);
   const itCount = (_only && _only.length) || _content.match(/\sit\(/g)?.length;
-  const testCount = (itCount ?? 0) * 3;
+  const testCount = (itCount ?? 0) * 4;
   while (testId++ < testCount) {
     await mkdir(dpath(''));
     await write(dpath('change.txt'), 'b');

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,11 @@ type BasicOpts = {
   interval: number;
   binaryInterval: number; // Used only for pooling and if different from interval
 
+  // Use a single native fs.watch(recursive: true) instance per watched
+  // directory tree, instead of one watcher per directory. Falls back to
+  // per-directory watchers on platforms without native recursive support.
+  useRecursiveWatch: boolean;
+
   alwaysStat?: boolean;
   depth?: number;
   ignorePermissionErrors: boolean;
@@ -120,6 +125,7 @@ function normalizePath(path: Path): Path {
 }
 
 function matchPatterns(patterns: MatchFunction[], testString: string, stats?: Stats): boolean {
+  if (patterns.length === 0) return false;
   const path = normalizePath(testString);
 
   for (let index = 0; index < patterns.length; index++) {
@@ -273,9 +279,6 @@ export class WatchHelper {
     this.watchPath = watchPath;
     this.fullWatchPath = sp.resolve(watchPath);
     this.dirParts = [];
-    this.dirParts.forEach((parts) => {
-      if (parts.length > 1) parts.pop();
-    });
     this.followSymlinks = follow;
     this.statMethod = follow ? STAT_METHOD_F : STAT_METHOD_L;
   }
@@ -368,6 +371,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
       binaryInterval: 300,
       followSymlinks: true,
       usePolling: false,
+      useRecursiveWatch: false,
       // useAsync: false,
       atomic: true, // NOTE: overwritten later (depends on usePolling)
       ..._opts,
@@ -379,9 +383,6 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
 
     // Always default to polling on IBM i because fs.watch() is not available on IBM i.
     if (isIBMi) opts.usePolling = true;
-    // Editor atomic write normalization enabled by default with fs.watch
-    if (opts.atomic === undefined) opts.atomic = !opts.usePolling;
-    // opts.atomic = typeof _opts.atomic === 'number' ? _opts.atomic : 100;
     // Global override. Useful for developers, who need to force polling for all
     // instances of chokidar, regardless of usage / dependency depth
     const envPoll = process.env.CHOKIDAR_USEPOLLING;
@@ -393,6 +394,9 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     }
     const envInterval = process.env.CHOKIDAR_INTERVAL;
     if (envInterval) opts.interval = Number.parseInt(envInterval, 10);
+    // Editor atomic write normalization enabled by default with fs.watch
+    if (_opts.atomic === undefined) opts.atomic = !opts.usePolling;
+    // opts.atomic = typeof _opts.atomic === 'number' ? _opts.atomic : 100;
     // This is done to emit ready only once, but each 'add' will increase that?
     let readyCalls = 0;
     this._emitReady = () => {
@@ -553,7 +557,10 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     this._readyCount = 0;
     this._readyEmitted = false;
     this._watched.forEach((dirent) => dirent.dispose());
+    this._pendingWrites.forEach((pw) => pw.cancelWait());
 
+    this._pendingWrites.clear();
+    this._pendingUnlinks.clear();
     this._closers.clear();
     this._watched.clear();
     this._streams.clear();
@@ -955,11 +962,14 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
 
   _readdirp(root: Path, opts?: Partial<ReaddirpOptions>): ReaddirpStream | undefined {
     if (this.closed) return;
-    const options = { type: EV.ALL, alwaysStat: true, lstat: true, ...opts, depth: 0 };
+    const options = { type: EV.ALL, alwaysStat: true, lstat: true, depth: 0, ...opts };
     let stream: ReaddirpStream | undefined = readdirp(root, options);
     this._streams.add(stream);
     stream.once(STR_CLOSE, () => {
-      stream = undefined;
+      if (stream) {
+        this._streams.delete(stream);
+        stream = undefined;
+      }
     });
     stream.once(STR_END, () => {
       if (stream) {


### PR DESCRIPTION
- one native fs.watch(root, { recursive: true }) per watched tree instead of one watcher per directory
- Enabled on Linux/macOS/Windows when usePolling is off; everything else (and a runtime fs.watch throw) falls back to the classic per-directory mode.

## Inner workings

- handler.ts — _handleDirRecursive creates the native watcher and runs a full-depth readdirp scan to build the DirEntry tree and emit initial events. _handleRecursiveEvent normalizes each raw event by lstat-ing the reported path and diffing against the tree: new dir ⇒ addDir + scan (catches trees moved in with contents), new file ⇒ add, tracked file ⇒ change, ENOENT ⇒ unlink/unlinkDir via the existing _remove. All events flow through _emit, so ignored, cwd, atomic, awaitWriteFinish, and depth keep working.
- Correctness subtleties that surfaced during testing: a create arrives as a rename+change pair, so a seen map (mtime/size + a 50ms post-add window) suppresses the duplicate change; ignored directories need explicit ancestor checks per event (per-dir mode gets that structurally); with followSymlinks: false the link itself is treated as a file so an atomic link replacement emits change (live realpath comparison proved racy); a tracked symlink's ENOENT is re-checked after 100ms before declaring unlink; readdirp is stopped from descending into symlinked dirs, which are delegated to the existing per-directory machinery.

## Benchmark (20k files + 2k dirs)

- Time to ready: 455ms => 240ms
- RSS after ready: 280MB => 96MB
- latency: 0.15ms => 0.06ms
- close(): 42ms => 20ms
- 500-file create burst: 95ms => 500ms (slower)
- kernel inotify watches: same

### larger bench

- New mode ready time: 1.78x faster at 100k, 2.10x faster at 400k.
- New mode RSS: 68.5% lower at 100k, 70.0% lower at 400k.
- New mode change latency: about 3.4x faster median.
- New mode close time: about 2.4x-2.5x faster.
- New mode 500-file add churn is slower here: about 9x-12x slower.
- On Linux, inotify watch count is unchanged between modes.


On Linux, Node emulates recursive watching in JS, so kernel watch counts don't drop — the memory/startup wins come from eliminating chokidar's per-path closer/listener machinery. And the create-burst slowdown is entirely Node's emulation layer: raw fs.watch(recursive) took ~558 ms to deliver the same 500 events, slightly slower than chokidar's wrapper. On macOS (FSEvents) and Windows (ReadDirectoryChangesW) it's one true kernel object, so resource wins should be substantially larger there — worth benchmarking before making it a default anywhere.