### PR TITLE
fix: keep watching subtree when also watching a non-existent nested path

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -575,11 +575,25 @@ export class NodeFsHandler {
         // Files that present in current directory snapshot
         // but absent in previous are added to watch list and
         // emit `add` event.
-        if (item === target || (!target && !previous.has(item))) {
+        //
+        // For subdirectories, "already handled" is tracked via `_scannedDirs`
+        // rather than `previous.has(item)`: a directory can be present in
+        // `previous` because it was only shallow-watched to detect a specific
+        // child (a `target` add for a non-existent nested path) without ever
+        // being read. Relying on `previous.has` there would make this recursive
+        // scan skip it and silently leave its subtree unwatched (#1470).
+        const childAbsPath = sp.resolve(directory, item);
+        const isDir = entry.stats.isDirectory();
+        const alreadyHandled = isDir ? this.fsw._scannedDirs.has(childAbsPath) : previous.has(item);
+        if (item === target || (!target && !alreadyHandled)) {
           this.fsw._incrReadyCount();
 
           // ensure relativeness of path is preserved in case of watcher reuse
           path = sp.join(dir, sp.relative(dir, path));
+
+          // Mark the directory as being read recursively before descending, so
+          // a concurrent scan of the same tree won't descend into it again.
+          if (isDir) this.fsw._scannedDirs.add(childAbsPath);
 
           this._addToNodeFs(path, initialAdd, wh, depth + 1);
         }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -891,6 +891,22 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
       ok(calledWith(spy, [EV.ADD_DIR, testDir]));
       ok(calledWith(spy, [EV.ADD, testPath]));
     });
+    it('should keep watching the subtree when also watching a non-existent deeply-nested path (#1470)', async () => {
+      const srcDir = dpath('a/b/c/src');
+      const file = dpath('a/b/c/src/counter.js');
+      // `a/b/c/public` is nested >=2 levels under the watched root and is never created.
+      const missingDir = dpath('a/b/c/public');
+      await mkdir(srcDir, { recursive: true });
+      await write(file, 'export const n = 1\n');
+
+      const watcher = cwatch([currentDir, missingDir], options);
+      const spy = await aspy(watcher, EV.CHANGE);
+
+      await delay();
+      await write(file, 'export const n = 2\n');
+      await waitFor([spy]);
+      ok(calledWith(spy, [file]));
+    });
   });
   describe('not watch glob patterns', () => {
     it('should not confuse glob-like filenames with globs', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,6 +327,11 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
   _streams: Set<ReaddirpStream>;
   _symlinkPaths: Map<Path, string | boolean>;
   _watched: Map<string, DirEntry>;
+  // Absolute paths of directories we've committed to reading recursively.
+  // A directory that is only shallow-watched to detect a specific child
+  // (a `target` add for a non-existent nested path) is intentionally absent,
+  // so a recursive scan of an overlapping parent still descends into it (#1470).
+  _scannedDirs: Set<string>;
 
   _pendingWrites: Map<string, any>;
   _pendingUnlinks: Map<string, EmitArgsWithName>;
@@ -351,6 +356,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     this._streams = new Set();
     this._symlinkPaths = new Map();
     this._watched = new Map();
+    this._scannedDirs = new Set();
 
     this._pendingWrites = new Map();
     this._pendingUnlinks = new Map();
@@ -915,6 +921,7 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     // or a bogus entry to a file, in either case we have to remove it
     this._watched.delete(path);
     this._watched.delete(fullPath);
+    this._scannedDirs.delete(fullPath);
     const eventName: EventName = isDirectory ? EV.UNLINK_DIR : EV.UNLINK;
     if (wasTracked && !this._isIgnored(path)) this._emit(eventName, path);
 


### PR DESCRIPTION
## Problem

When `watch()` received both a directory watched recursively and a non-existent path nested two or more levels below it, the missing path's existing parent was registered as a shallow "target" watch. This marked the directory as tracked in its parent's `DirEntry` without ever reading it. The recursive scan of the overlapping root then treated that directory as already handled (via `_handleRead`'s `previous.has(item)` check) and never descended into it, silently leaving its whole subtree unwatched. No error was emitted and `ready` still fired.

## Fix

Track directories we've committed to reading recursively in a dedicated `_scannedDirs` set and use it (instead of parent-`DirEntry` membership) to decide whether to descend into a subdirectory. A directory that is only shallow-watched for a specific child is intentionally absent from the set, so an overlapping recursive scan still descends into it.

## Testing

Added a regression test covering the scenario where a recursively watched directory and a non-existent nested path (two or more levels deep) are watched together, verifying the subtree remains watched. Existing test suite passes.

Closes #1470
