### PR TITLE
fix: register watcher before dir scan to avoid missing files created during scan

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -651,17 +651,36 @@ export class NodeFsHandler {
 
     const oDepth = this.fsw.options.depth;
     if ((oDepth == null || depth <= oDepth) && !this.fsw._symlinkPaths.has(realpath)) {
-      if (!target) {
-        await this._handleRead(dir, initialAdd, wh, target, dir, depth, throttler);
-        if (this.fsw.closed) return;
-      }
-
+      // Register the fs watcher BEFORE running the initial readdirp scan.
+      //
+      // Previously the scan (`_handleRead`) ran to completion and only then was
+      // the watcher attached. That left a window in which a file created inside
+      // `dir` while the scan was in progress was reported by neither side: the
+      // scan had already listed the directory contents (before the file
+      // existed) and the watcher was not attached yet, so the `add` event was
+      // silently lost (#1471 — a regression of the same race fixed in #1112).
+      //
+      // Attaching the watcher first means any creation during the scan fires the
+      // watcher, which re-reads the directory. The `previous`/`current` diff in
+      // `_handleRead` dedupes against entries the initial scan already emitted,
+      // so files reported by the scan do not produce a duplicate `add`.
       closer = this._watchWithNodeFs(dir, (dirPath, stats) => {
         // if current directory is removed, do nothing
         if (stats && stats.mtimeMs === 0) return;
 
         this._handleRead(dirPath, false, wh, target, dir, depth, throttler);
       });
+
+      if (!target) {
+        await this._handleRead(dir, initialAdd, wh, target, dir, depth, throttler);
+        if (this.fsw.closed) {
+          // The watcher was attached before the scan; if we were closed during
+          // the scan its closer will not be registered, so release it here to
+          // avoid leaking the underlying fs_watch handle.
+          if (closer) closer();
+          return;
+        }
+      }
     }
     return closer;
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -559,6 +559,45 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
       ok(spy.calls[0][1]); // stats
       ok(rawSpy.called);
     });
+    it('should notice a file created in a new directory during its scan (#1471)', async () => {
+      const testDir = dpath('subdir');
+      const testPath = dpath('subdir/add.txt');
+      const spy = createSpy<EmitArgs, void>(function addSpy() {});
+      watcher.on(EV.ADD, spy);
+      equal(spy.called, false);
+
+      // Deterministically widen the race window from #1471. When the freshly
+      // added `subdir` is scanned, let the real scan of the (still empty) dir
+      // run, then create a file inside it *before* returning - i.e. inside the
+      // gap where the fs watcher used to be attached only after the scan had
+      // finished. If the watcher is attached after the scan (the bug), the fs
+      // event for this creation has no listener and the scan already listed the
+      // dir as empty, so the `add` is lost forever.
+      const handler = (watcher as unknown as { _nodeFsHandler: any })._nodeFsHandler;
+      const origHandleRead = handler._handleRead.bind(handler);
+      let injected = false;
+      handler._handleRead = (...args: any[]) => {
+        const directory = args[0];
+        const target = args[3];
+        if (!injected && !target && sp.basename(directory) === 'subdir') {
+          injected = true;
+          return (async () => {
+            const res = await origHandleRead(...args);
+            await write(testPath, time());
+            await delay(200);
+            return res;
+          })();
+        }
+        return origHandleRead(...args);
+      };
+
+      await mkdir(testDir);
+      await waitFor([spy]);
+      ok(injected); // ensure the widened window actually exercised the fix
+      equal(spy.callCount, 1); // exactly one `add`, no duplicates
+      ok(calledWith(spy, [testPath]));
+      ok(spy.calls[0][1]); // stats
+    });
     it('should watch removed and re-added directories', async () => {
       const unlinkSpy = createSpy<EmitArgs, void>(function unlinkSpy() {});
       const addSpy = createSpy<EmitArgs, void>(function addSpy() {});


### PR DESCRIPTION
## What

Fixes a race where a file created inside a newly-added directory during that directory's initial scan is silently missed (no `add` event). This is a regression of the same race fixed for #1112 — the ordering had drifted back to scan-then-watch.

## Why

In `src/handler.ts` `_handleDir`, the initial `readdirp` scan (`_handleRead`) ran to completion **before** the fs watcher was attached via `_watchWithNodeFs`. A file created inside the directory during that window was reported by neither side: the scan had already listed the (empty) directory, and the watcher was not attached yet.

## How

Attach the watcher **before** the scan, so an in-scan creation fires the (already-live) watcher, which re-reads the directory.

Deduplication is inherent: `_handleRead`'s existing `previous`/`current` diff only emits `add` for entries not already seen, so files the initial scan already reported never produce a duplicate `add`. A guard releases the freshly-created watcher if the `FSWatcher` is closed mid-scan, to avoid leaking the handle.

## Testing

- Added a regression test in `src/index.test.ts` that deterministically widens the window (wraps `_handleRead` for the new subdir to create a file mid-scan), then asserts exactly one `add` fires — passing under both `fs.watch` (non-polling) and `fs.watchFile` (polling).
- Before: the test times out, the `add` never fires. After: full suite `209 passing`, 0 failing. Verified the test exercises the built code (revert `handler.ts` → red, restore → green).

Closes #1471
