### PR TITLE
fix: avoid re-adding self when dealing with relative paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -490,7 +490,12 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     ).then((results) => {
       if (this.closed) return;
       results.forEach((item) => {
-        if (item) this.add(sp.dirname(item), sp.basename(_origAdd || item));
+        if (!item) return;
+        const parent = sp.dirname(item);
+        // if the parent is itself, its probably `.` or similar, so skip it
+        // to avoid infinite recursion
+        if (parent === item) return;
+        this.add(parent, sp.basename(_origAdd || item));
       });
     });
 


### PR DESCRIPTION
Things like `.`, `/`, etc have a `dirname(...)` equal to themselves.

In these situations, we end up adding the `item` again which can
sometimes result in an infinite loop.

Fixes #1474.
