### PR TITLE
fix: settle directory read when readdirp stream is destroyed

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -588,6 +588,13 @@ export class NodeFsHandler {
 
     return new Promise((resolve, reject) => {
       if (!stream) return reject();
+      // A stream destroyed by an error never emits `end`, and neither does one
+      // abandoned after the watcher was closed. `close` always follows, so settle
+      // there too: leaving this pending stalls _handleDir and the ready counter.
+      stream.once(STR_CLOSE, () => {
+        stream = undefined;
+        resolve(undefined);
+      });
       stream.once(STR_END, () => {
         if (this.fsw.closed) {
           stream = undefined;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1123,6 +1123,16 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
       await waitForWatcher(watcher);
       equal(readySpy.callCount, 1);
     });
+    it('should emit ready event when a symlink target path passes through a file', async () => {
+      options.followSymlinks = false;
+      // Resolving this link fails with ENOTDIR rather than the ENOENT of a
+      // dangling one, because its target path descends into a regular file.
+      await symlink(dpath('subdir/add.txt/nope'), dpath('subdir/notdir'));
+      const readySpy = createSpy(function readySpy() {});
+      const watcher = cwatch(dpath('subdir'), options).on(EV.READY, readySpy);
+      await waitForWatcher(watcher);
+      equal(readySpy.callCount, 1);
+    });
   });
   describe('watch arrays of paths/globs', () => {
     it('should watch all paths in an array', async () => {


### PR DESCRIPTION
Fixes #1476.

## The bug

`_handleRead` returns a promise that is resolved only from the stream's `end`
listener (`src/handler.ts`). A readdirp stream that gets destroyed by an error
never emits `end`, so that promise stays pending forever. `_handleDir` awaits it,
so:

- the `_watchWithNodeFs` call after the `await` never runs — the directory ends up
  with no watcher at all,
- the pending ready count is never decremented, so `ready` never fires for the
  whole watcher, not just that directory.

Nothing is reported either, so the caller sees a watcher that is simply stuck.

The reachable trigger from #1476 is a symlink whose target path descends into a
regular file. readdirp calls `realpath()` on symlink entries and only tolerates a
fixed set of errnos (`ENOENT`, `EPERM`, `EACCES`, `ELOOP`, recursion); anything
else calls `destroy(err)`. `ENOTDIR` is not in that set, so one such link kills
the listing of its whole directory. A merely dangling link (`ENOENT`) is fine,
which makes this easy to misdiagnose.

Reproducer (from the issue, verified on `main`):

```js
import { mkdtempSync, writeFileSync, symlinkSync } from 'node:fs';
import { join } from 'node:path';
import { tmpdir } from 'node:os';
import chokidar from 'chokidar';

const root = mkdtempSync(join(tmpdir(), 'enotdir-'));
writeFileSync(join(root, 'regular.txt'), 'hi\n');
symlinkSync(join(root, 'regular.txt', 'nope'), join(root, 'poison'));

const w = chokidar.watch(root, { followSymlinks: false });
w.on('ready', () => console.log('READY'));
w.on('error', (e) => console.log('ERROR', e.code));
w.on('all', (ev, p) => console.log('EVENT', ev, p));
setTimeout(() => w.close(), 3000);
```

Before: only `EVENT addDir <root>`, then nothing — no `READY`, ever.
After: `EVENT addDir <root>` followed by `READY`.

## The fix

Settle the promise on `close` as well as `end`. `close` follows both a normal
`end` (readdirp sets `autoDestroy: true`) and a `destroy(err)`, so the listing
promise now resolves however the stream terminates. `resolve` is idempotent, so
the normal path is unchanged — the existing `end` listener still does the
snapshot-diff / `_remove` / throttle-retry work first, and that work is
deliberately *not* run for a destroyed stream, since a truncated listing would
make the diff unlink files that still exist.

This also covers the second non-settling path in the same block: the `end`
listener returns early without resolving when `this.fsw.closed` is already true.

## Why here

The issue also points at readdirp, and that is fair — adding `ENOTDIR` to
readdirp's `NORMAL_FLOW_ERRORS` would let the rest of that directory be listed,
which this patch does not do on its own. But the two are independent. Whatever
errno readdirp decides to destroy a stream over, chokidar should not respond by
hanging forever with no `ready` and no error, and that is a chokidar-side defect
in `_handleRead`. Happy to follow up on the readdirp side separately if you want
the entries after the bad link to be picked up too.

Nothing else was changed: `_handleError` still deliberately swallows `ENOTDIR`
(and `ENOENT`) rather than emitting `error`, so this does not add a new error
event to anyone's watcher.

## Test

`should emit ready event when a symlink target path passes through a file`, next
to the existing broken-symlink ready test in `watch symlinks`. It runs under both
the polling and non-polling variants.

Fail-before (fix reverted, test only):

```
chokidar
└─fs.watchFile (polling)
  ├─watch symlinks
  │ └─should emit ready event when a symlink target path passes through a file: ☓
Error: timeout
    at Timeout._onTimeout (file:///.../index.test.js:70:20)
```

Pass-after:

```
chokidar
└─fs.watchFile (polling)
  ├─watch symlinks
  │ └─should emit ready event when a symlink target path passes through a file: ✓

1 tests passed in 1 sec
```

Full suite, Linux / Node 22: `207 tests passed` on `main`, `209 tests passed`
with this branch (the new test counts once per variant). Ran five times on the
branch, clean each time. `prettier --check src` and `tsc` are clean.

Note for context: the suite is flaky on my machine *without* this patch — two
of four `main` runs failed, on `should ignore unwatched siblings` and
`should close the fs.watch handle of a deleted watched directory` respectively.
That is pre-existing and unrelated; I did not touch it.
