### PR TITLE
Route a rejection from add() into the error event instead of an unhandled rejection

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1991,6 +1991,43 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
     });
   });
 
+  describe('reproduction of bug in issue #1378', () => {
+    it('should emit an error event instead of an unhandled rejection when add() fails internally', async () => {
+      // Watch nothing initially so the only _addToNodeFs call under test is
+      // the explicit watcher.add() below, not an unrelated directory scan.
+      const watcher = cwatch([], { persistent: true });
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        const caught = new Promise<Error>((resolve, reject) => {
+          const timeout = setTimeout(
+            () => reject(new Error('timed out waiting for an error event')),
+            2000
+          );
+          watcher.once('error', (err: unknown) => {
+            clearTimeout(timeout);
+            resolve(err as Error);
+          });
+        });
+        // Simulate the ENOSPC-style failure reported in the issue: something
+        // inside _addToNodeFs rejects after add() has already returned
+        // synchronously, so the caller has no way to .catch() it directly.
+        (watcher as any)._nodeFsHandler._addToNodeFs = async () => {
+          throw new Error('simulated ENOSPC from _addToNodeFs');
+        };
+        watcher.add(sp.join(currentDir, 'somefile-for-1378'));
+        const error = await caught;
+        ok(error.message.includes('simulated ENOSPC from _addToNodeFs'));
+        await delay(50);
+        deepEqual(unhandled, []);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+        watcher.close();
+      }
+    });
+  });
+
   it('should close the fs.watch handle of a deleted watched directory', async () => {
     const id = testId.toString();
     const watchedDir = sp.join(FIXTURES_PATH, id, 'to-delete');

--- a/src/index.ts
+++ b/src/index.ts
@@ -487,12 +487,21 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
         if (res) this._emitReady();
         return res;
       })
-    ).then((results) => {
-      if (this.closed) return;
-      results.forEach((item) => {
-        if (item) this.add(sp.dirname(item), sp.basename(_origAdd || item));
+    )
+      .then((results) => {
+        if (this.closed) return;
+        results.forEach((item) => {
+          if (item) this.add(sp.dirname(item), sp.basename(_origAdd || item));
+        });
+      })
+      .catch((error) => {
+        // Route a rejection from _addToNodeFs (e.g. ENOSPC when the OS is out
+        // of file watchers) through the same error path everything else in
+        // this class uses, instead of letting it become an unhandled
+        // rejection with no way for a caller to hear about it. add() itself
+        // stays synchronous, so this is the only way to surface the failure.
+        this._handleError(error);
       });
-    });
 
     return this;
   }


### PR DESCRIPTION
Fixes #1378.

`add()` kicks off `Promise.all(...)` internally but returns synchronously, so a rejection from `_addToNodeFs` (an ENOSPC when the OS runs out of file watchers, per the issue's stack trace) had nowhere to go and became a global unhandled rejection.

Since making `add()` async would be a breaking change, I went with what @43081j suggested on the thread: route it through the existing `_handleError()` path instead, same mechanism every other internal failure in this class already uses. Benign errors (ENOENT, ENOTDIR, permission errors when configured) still get filtered out there, so this only changes behavior for genuine failures.

Added a regression test that patches `_addToNodeFs` to reject and confirms an `error` event fires instead of a process-level unhandled rejection. Full suite passes locally (209 tests, both the plain and polling variants).