### PR TITLE
fix: close a dir watcher when close() lands during its add

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -718,7 +718,10 @@ export class NodeFsHandler {
           wh,
           targetPath
         );
-        if (this.fsw.closed) return;
+        if (this.fsw.closed) {
+          if (closer) closer();
+          return;
+        }
         // preserve this symlink's target path
         if (absPath !== targetPath && targetPath !== undefined) {
           this.fsw._symlinkPaths.set(absPath, targetPath);
@@ -730,7 +733,10 @@ export class NodeFsHandler {
         this.fsw._getWatchedDir(parent).add(wh.watchPath);
         this.fsw._emit(EV.ADD, wh.watchPath, stats);
         closer = await this._handleDir(parent, stats, initialAdd, depth, path, wh, targetPath);
-        if (this.fsw.closed) return;
+        if (this.fsw.closed) {
+          if (closer) closer();
+          return;
+        }
 
         // preserve this symlink's target path
         if (targetPath !== undefined) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -892,6 +892,26 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
       ok(calledWith(spy, [EV.ADD, testPath]));
     });
   });
+  describe('close during scan', () => {
+    it('closes a dir handle whose closer close() can no longer register', async () => {
+      const testDir = dpath('race');
+      await mkdir(testDir);
+      const watcher = new chokidar.FSWatcher(options);
+      const w: any = watcher._nodeFsHandler;
+      const orig = w._watchWithNodeFs.bind(w);
+      const leaks = () =>
+        (process as any).getActiveResourcesInfo().filter((r: string) => r === 'FSEventWrap').length;
+      const baseline = leaks();
+      w._watchWithNodeFs = (path: string, listener: unknown) => {
+        const closer = orig(path, listener);
+        if (sp.normalize(path) === sp.normalize(testDir)) void watcher.close();
+        return closer;
+      };
+      watcher.add(testDir);
+      await delay(100);
+      ok(leaks() <= baseline);
+    });
+  });
   describe('not watch glob patterns', () => {
     it('should not confuse glob-like filenames with globs', async () => {
       const filePath = dpath('nota[glob].txt');


### PR DESCRIPTION
Fixes #1482

## Summary

`_addToNodeFs()` registers the closer returned by `_handleDir()` with `_addPathCloser()` only after re-checking `this.fsw.closed`. When `close()` lands inside that await gap, it sweeps a still-empty `_closers` list, the resumed `_addToNodeFs` discards the closer, and the `fs.watch` handle created moments earlier is orphaned — nothing ever closes it and the process stays alive indefinitely.

This adds one disposal at each of the two drop points (directory branch, symlink-parent branch): invoke the closer instead of returning past it. The `_handleFile` path is synchronous and has no gap, so it needs nothing.

Details, real-world impact (a vite dev-server suite hung on CI with every test passing), and an independent forced-interleave reproduction of the exact drop point: #1482, https://github.com/apache/maka/issues/4940

## Verification

- New regression test `close during scan > closes a dir handle whose closer close() can no longer register`: it forces `close()` to land between the directory `fs.watch` creation and the closer registration, then asserts no `FSEventWrap` survives.
- With the fix: **209 tests passed** (node 24, Linux docker; same on macOS node 26).
- Without the fix (both sites reverted, verified 2 → 0): the new test **fails** on Linux — the orphaned handle is detected.
- `npm run lint` and `npm run build` clean.

Note for downstream: vite vendors chokidar 3.6.0 via `patches/chokidar@3.6.0.patch` and 3.6.0 is EOL, so their patch needs the same disposal for bundled-3.6.0 users until they can bump.

Generated-by: GLM-5.3-Flash (pi)