### PR TITLE
fix: don't retry add() when dirname is the same path

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2109,6 +2109,30 @@ describe('chokidar', async () => {
     ok(typeof chokidar.watch === 'function');
   });
 
+  describe('issue #1474', () => {
+    it('should stop walking up when dirname equals the missing path', async () => {
+      const watcher = new chokidar.FSWatcher({
+        persistent: false,
+        usePolling: true,
+        interval: 100,
+        ignoreInitial: true,
+      });
+      WATCHERS.push(watcher);
+      let calls = 0;
+      watcher._nodeFsHandler._addToNodeFs = async (path: string) => {
+        calls++;
+        return path;
+      };
+      watcher.add('sub/spec.yaml');
+      await delay(80);
+      await watcher.close();
+      ok(
+        calls >= 3 && calls <= 8,
+        `add() walk-up should stop at the path root, got ${calls} attempts`
+      );
+    });
+  });
+
   if (!isIBMi) {
     describe('fs.watch (non-polling)', runTests.bind(this, { usePolling: false }));
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -490,7 +490,11 @@ export class FSWatcher extends EventEmitter<FSWatcherEventMap> {
     ).then((results) => {
       if (this.closed) return;
       results.forEach((item) => {
-        if (item) this.add(sp.dirname(item), sp.basename(_origAdd || item));
+        if (!item) return;
+        const parent = sp.dirname(item);
+        // dirname('.') === '.' and dirname('/') === '/'. Retrying those never makes progress.
+        if (parent === item) return;
+        this.add(parent, sp.basename(_origAdd || item));
       });
     });
 


### PR DESCRIPTION
When a relative watch is the only file and its tree (including cwd) goes away, add() keeps retrying on dirname. For `.`, dirname is still `.`, so that retry never moves and you get a silent 100% CPU loop of failed stats.

This stops the walk-up once dirname equals the path, so `.` and `/` are terminal. Watching the parent so a file can come back still works while that parent exists. The test stubs the missing-path return so we don't have to delete cwd.

Fixes #1474
