### PR TITLE
fix: do not ignore fallback parent of a missing watch path (#1374)

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -683,7 +683,9 @@ export class NodeFsHandler {
     target?: string
   ): Promise<string | false | undefined> {
     const ready = this.fsw._emitReady;
-    if (this.fsw._isIgnored(path) || this.fsw.closed) {
+    // When `target` is set, `path` is a fallback parent of a missing watch path
+    // that already passed ignored. Do not ignore the parent (issue #1374).
+    if ((!target && this.fsw._isIgnored(path)) || this.fsw.closed) {
       ready();
       return false;
     }
@@ -698,7 +700,7 @@ export class NodeFsHandler {
     try {
       const stats = await statMethods[wh.statMethod](wh.watchPath);
       if (this.fsw.closed) return;
-      if (this.fsw._isIgnored(wh.watchPath, stats)) {
+      if (!target && this.fsw._isIgnored(wh.watchPath, stats)) {
         ready();
         return false;
       }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -891,6 +891,42 @@ const runTests = (baseopts: chokidar.ChokidarOptions) => {
       ok(calledWith(spy, [EV.ADD_DIR, testDir]));
       ok(calledWith(spy, [EV.ADD, testPath]));
     });
+    it('should watch non-existent file even if ignored matches its parent', async () => {
+      const testPath = dpath('add.js');
+      const siblingPath = dpath('sibling.txt');
+      options.ignored = (path) => !path.endsWith('.js');
+      const watcher = cwatch(testPath, options);
+      const spy = await aspy(watcher, EV.ALL);
+
+      await delay();
+      await write(siblingPath, time());
+      await write(testPath, time());
+      await waitFor([[spy, 1, [EV.ADD, testPath]]]);
+      ok(calledWith(spy, [EV.ADD, testPath]));
+      equal(calledWith(spy, [EV.ADD, siblingPath]), false);
+    });
+    it('should watch non-existent file even if ignored matches directories', async () => {
+      const testPath = dpath('add.txt');
+      options.ignored = (_path, stats) => !!stats && stats.isDirectory();
+      const watcher = cwatch(testPath, options);
+      const spy = await aspy(watcher, EV.ADD);
+
+      await delay();
+      await write(testPath, time());
+      await waitFor([spy]);
+      ok(calledWith(spy, [testPath]));
+    });
+    it('should still ignore a missing path that itself matches ignored', async () => {
+      const testPath = dpath('add.txt');
+      options.ignored = (path) => path.endsWith('.txt');
+      const watcher = cwatch(testPath, options);
+      const spy = await aspy(watcher, EV.ADD);
+
+      await delay();
+      await write(testPath, time());
+      await delay(300);
+      equal(spy.called, false);
+    });
   });
   describe('not watch glob patterns', () => {
     it('should not confuse glob-like filenames with globs', async () => {


### PR DESCRIPTION
## Summary
- Watching a path that does not exist yet falls back to the parent directory. `ignored` was applied to that parent, so a matcher that rejects directories (or anything that is not the file) prevented the fallback watch from ever being installed.
- If the originally requested path already passed `ignored`, skip `ignored` on the fallback parent. The parent is still watched only for that child (`target`); siblings stay filtered.
- Adds tests for a path matcher that matches the parent, a stats matcher that matches directories, and a guard that a missing path which itself matches `ignored` is still ignored.

Fixes #1374

## Decision
- Chose: skip `ignored` on fallback parents (`target` set) in `_addToNodeFs`.
- Alternative: leave behaviour as-is and document that matchers must allow the parent, or treat every ancestor of a user-supplied path as un-ignoreable.
- Reasoning: `_handleDir` already treats `target` as a stand-in for one child; ignore on the parent was the leftover hole. Matches the issue: if the missing file passed `ignored`, the parent should automatically pass.
- Happy to keep exact-string ignores of the parent in force if that is preferred.

## Test plan
- [x] `should watch non-existent file even if ignored matches its parent` (polling; fails without the change)
- [x] `should watch non-existent file even if ignored matches directories` (polling; fails without the change)
- [x] `should still ignore a missing path that itself matches ignored`
- [x] existing `should watch non-existent file and detect add`
- [x] existing `should not choke on an ignored watch path`
- [x] default `fs.watch` repro of both ignore cases
- [ ] full `npm test` matrix (fs.watch + polling) on CI
